### PR TITLE
chore: bump Quarkus 3.34.2 → 3.34.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.shadow)
     alias(libs.plugins.proto.toolchain)
     id 'idea'
-    id 'io.quarkus' version '3.34.2'
+    id 'io.quarkus' version '3.34.3'
 }
 
 scmVersion {
@@ -73,7 +73,7 @@ pipestreamProtos {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:3.34.2")
+    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:3.34.3")
     implementation 'io.quarkus:quarkus-arc'
 
     implementation libs.wiremock.core

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=0.1.52
-quarkusVersion=3.34.2
+quarkusVersion=3.34.3
 grpcVersion=1.79.0
 protobufVersion=4.33.5
 


### PR DESCRIPTION
## Summary

Bumps Quarkus from 3.34.2 to 3.34.3 to match the ecosystem-wide bump in [pipestream-platform#50](https://github.com/ai-pipestream/pipestream-platform/pull/50).

Three-line diff:
- `gradle.properties`: `quarkusVersion=3.34.3`
- `build.gradle`: `id 'io.quarkus' version '3.34.3'`
- `build.gradle`: `quarkus-bom:3.34.3`

## Note on generateProtos

On this development host, `./gradlew generateProtos` fails with a `protoc-gen-grpc-java` SIGKILL. **This is a pre-existing issue unrelated to the Quarkus bump** — verified by reverting the bump locally and seeing the same SIGKILL.

Root cause: the cached proto export contains the old `quality_profile.proto` with `java_outer_classname = "QualityProfile"` (which collides with the top-level `QualityProfile` message). Fixed upstream in [pipestream-protos#33](https://github.com/ai-pipestream/pipestream-protos/pull/33) (merged). Fresh `fetchProtos` will pick up the fix.

## Test plan

- [x] `git diff` — only 3 version strings changed
- [ ] Fresh checkout + `./gradlew fetchProtos generateProtos` — should succeed with PR #33's fix in place
- [ ] Full `./gradlew build` — after the proto fetch succeeds
