### PR TITLE
feat(mocks): semantic pipeline step mocks (Chunker/Embedder/SemanticGraph) for contract lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,14 @@ dependencies {
     testImplementation libs.junit.jupiter
     testImplementation libs.assertj.core
     testRuntimeOnly libs.junit.platform.launcher
+
+    // pipestream-test-support provides SemanticPipelineInvariants for the
+    // semantic-pipeline step mock tests. Non-transitive: wiremock-server is
+    // not a Quarkus project, so we only want the thin class set from the jar,
+    // not the transitive Quarkus / testcontainers deps.
+    testImplementation('ai.pipestream:pipestream-test-support:0.7.24-SNAPSHOT') {
+        transitive = false
+    }
 }
 
 // Configure source sets for proto-toolchain generated code

--- a/src/main/java/ai/pipestream/wiremock/client/ChunkerStepMock.java
+++ b/src/main/java/ai/pipestream/wiremock/client/ChunkerStepMock.java
@@ -1,0 +1,77 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.wiremock.client.semantic.SemanticFixtureBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.protobuf.util.JsonFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+/**
+ * Header-scoped mock for the semantic pipeline's chunker step.
+ *
+ * <p>Registers a high-priority stub on
+ * {@link PipeStepProcessorServiceGrpc#SERVICE_NAME}'s {@code ProcessData} method
+ * that fires only when the gRPC request carries {@code x-module-name: chunker}.
+ * Returns a canned stage-1 {@link ai.pipestream.data.v1.PipeDoc} built by
+ * {@link SemanticFixtureBuilder#buildStage1PipeDoc()} — the exact shape required
+ * by {@code SemanticPipelineInvariants.assertPostChunker}.
+ *
+ * <p>Coexists with the existing {@link PipeStepProcessorMock}, which handles
+ * {@code GetServiceRegistration} and the default (non-header-scoped)
+ * {@code ProcessData} catchall. Multiple {@link ServiceMockInitializer}
+ * implementations can target the same gRPC service — the registry invokes each
+ * in sequence at startup.
+ *
+ * <p>This class only handles the SUCCESS scenario in its current form. Failure
+ * and partial scenarios (fail-precondition, fail-invalid-arg, fail-internal,
+ * partial, slow) will be added in follow-up commits once the success path is
+ * validated end-to-end.
+ */
+public class ChunkerStepMock implements ServiceMockInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChunkerStepMock.class);
+
+    private static final String SERVICE_NAME = PipeStepProcessorServiceGrpc.SERVICE_NAME;
+    private static final String MODULE_NAME = "chunker";
+    private static final String MODULE_NAME_HEADER = "x-module-name";
+    private static final int HEADER_STUB_PRIORITY = 1;
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public void initializeDefaults(WireMock wireMock) {
+        registerSuccessScenario(wireMock);
+        LOG.info("ChunkerStepMock registered success scenario for x-module-name={}", MODULE_NAME);
+    }
+
+    private void registerSuccessScenario(WireMock wireMock) {
+        ProcessDataResponse response = ProcessDataResponse.newBuilder()
+                .setOutcome(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS)
+                .setOutputDoc(SemanticFixtureBuilder.buildStage1PipeDoc())
+                .build();
+
+        String grpcPath = "/" + SERVICE_NAME + "/ProcessData";
+        try {
+            String responseJson = JsonFormat.printer().print(response);
+            wireMock.register(
+                    post(urlPathEqualTo(grpcPath))
+                            .withHeader(MODULE_NAME_HEADER, equalTo(MODULE_NAME))
+                            .atPriority(HEADER_STUB_PRIORITY)
+                            .willReturn(okJson(responseJson)));
+        } catch (Exception e) {
+            LOG.error("Failed to register ChunkerStepMock success scenario", e);
+            throw new IllegalStateException("ChunkerStepMock init failed", e);
+        }
+    }
+}

--- a/src/main/java/ai/pipestream/wiremock/client/EmbedderStepMock.java
+++ b/src/main/java/ai/pipestream/wiremock/client/EmbedderStepMock.java
@@ -1,0 +1,70 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.wiremock.client.semantic.SemanticFixtureBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.protobuf.util.JsonFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+/**
+ * Header-scoped mock for the semantic pipeline's embedder step.
+ *
+ * <p>Registers a high-priority stub on
+ * {@link PipeStepProcessorServiceGrpc#SERVICE_NAME}'s {@code ProcessData} method
+ * that fires only when the gRPC request carries {@code x-module-name: embedder}.
+ * Returns a canned stage-2 {@link ai.pipestream.data.v1.PipeDoc} built by
+ * {@link SemanticFixtureBuilder#buildStage2PipeDoc()} — the exact shape required
+ * by {@code SemanticPipelineInvariants.assertPostEmbedder}.
+ *
+ * <p>This class only handles the SUCCESS scenario in its current form. Failure
+ * and partial scenarios land in follow-up commits once Phase 3 module agents
+ * actually need them.
+ */
+public class EmbedderStepMock implements ServiceMockInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbedderStepMock.class);
+
+    private static final String SERVICE_NAME = PipeStepProcessorServiceGrpc.SERVICE_NAME;
+    private static final String MODULE_NAME = "embedder";
+    private static final String MODULE_NAME_HEADER = "x-module-name";
+    private static final int HEADER_STUB_PRIORITY = 1;
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public void initializeDefaults(WireMock wireMock) {
+        registerSuccessScenario(wireMock);
+        LOG.info("EmbedderStepMock registered success scenario for x-module-name={}", MODULE_NAME);
+    }
+
+    private void registerSuccessScenario(WireMock wireMock) {
+        ProcessDataResponse response = ProcessDataResponse.newBuilder()
+                .setOutcome(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS)
+                .setOutputDoc(SemanticFixtureBuilder.buildStage2PipeDoc())
+                .build();
+
+        String grpcPath = "/" + SERVICE_NAME + "/ProcessData";
+        try {
+            String responseJson = JsonFormat.printer().print(response);
+            wireMock.register(
+                    post(urlPathEqualTo(grpcPath))
+                            .withHeader(MODULE_NAME_HEADER, equalTo(MODULE_NAME))
+                            .atPriority(HEADER_STUB_PRIORITY)
+                            .willReturn(okJson(responseJson)));
+        } catch (Exception e) {
+            LOG.error("Failed to register EmbedderStepMock success scenario", e);
+            throw new IllegalStateException("EmbedderStepMock init failed", e);
+        }
+    }
+}

--- a/src/main/java/ai/pipestream/wiremock/client/SemanticGraphStepMock.java
+++ b/src/main/java/ai/pipestream/wiremock/client/SemanticGraphStepMock.java
@@ -1,0 +1,70 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.wiremock.client.semantic.SemanticFixtureBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.protobuf.util.JsonFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+/**
+ * Header-scoped mock for the semantic pipeline's semantic-graph step.
+ *
+ * <p>Registers a high-priority stub on
+ * {@link PipeStepProcessorServiceGrpc#SERVICE_NAME}'s {@code ProcessData} method
+ * that fires only when the gRPC request carries {@code x-module-name: semantic-graph}.
+ * Returns a canned stage-3 {@link ai.pipestream.data.v1.PipeDoc} built by
+ * {@link SemanticFixtureBuilder#buildStage3PipeDoc()} — the exact shape required
+ * by {@code SemanticPipelineInvariants.assertPostSemanticGraph}.
+ *
+ * <p>This class only handles the SUCCESS scenario in its current form. Failure
+ * and partial scenarios land in follow-up commits once Phase 3 module agents
+ * actually need them.
+ */
+public class SemanticGraphStepMock implements ServiceMockInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SemanticGraphStepMock.class);
+
+    private static final String SERVICE_NAME = PipeStepProcessorServiceGrpc.SERVICE_NAME;
+    private static final String MODULE_NAME = "semantic-graph";
+    private static final String MODULE_NAME_HEADER = "x-module-name";
+    private static final int HEADER_STUB_PRIORITY = 1;
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public void initializeDefaults(WireMock wireMock) {
+        registerSuccessScenario(wireMock);
+        LOG.info("SemanticGraphStepMock registered success scenario for x-module-name={}", MODULE_NAME);
+    }
+
+    private void registerSuccessScenario(WireMock wireMock) {
+        ProcessDataResponse response = ProcessDataResponse.newBuilder()
+                .setOutcome(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS)
+                .setOutputDoc(SemanticFixtureBuilder.buildStage3PipeDoc())
+                .build();
+
+        String grpcPath = "/" + SERVICE_NAME + "/ProcessData";
+        try {
+            String responseJson = JsonFormat.printer().print(response);
+            wireMock.register(
+                    post(urlPathEqualTo(grpcPath))
+                            .withHeader(MODULE_NAME_HEADER, equalTo(MODULE_NAME))
+                            .atPriority(HEADER_STUB_PRIORITY)
+                            .willReturn(okJson(responseJson)));
+        } catch (Exception e) {
+            LOG.error("Failed to register SemanticGraphStepMock success scenario", e);
+            throw new IllegalStateException("SemanticGraphStepMock init failed", e);
+        }
+    }
+}

--- a/src/main/java/ai/pipestream/wiremock/client/semantic/SemanticFixtureBuilder.java
+++ b/src/main/java/ai/pipestream/wiremock/client/semantic/SemanticFixtureBuilder.java
@@ -1,0 +1,252 @@
+package ai.pipestream.wiremock.client.semantic;
+
+import ai.pipestream.data.v1.ChunkEmbedding;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.data.v1.SearchMetadata;
+import ai.pipestream.data.v1.SemanticChunk;
+import ai.pipestream.data.v1.SemanticProcessingResult;
+import ai.pipestream.data.v1.SourceFieldAnalytics;
+import ai.pipestream.data.v1.NlpDocumentAnalysis;
+import ai.pipestream.data.v1.NamedEmbedderConfig;
+import ai.pipestream.data.v1.VectorDirective;
+import ai.pipestream.data.v1.VectorSetDirectives;
+import ai.pipestream.data.v1.GranularityLevel;
+import ai.pipestream.data.v1.CentroidMetadata;
+import com.google.protobuf.Value;
+
+/**
+ * Builds canonical stage-1 / stage-2 / stage-3 {@link PipeDoc} fixtures for the
+ * semantic pipeline step mocks.
+ *
+ * <p>These builders produce the exact shapes required by the invariants defined
+ * in {@code SemanticPipelineInvariants} (in pipestream-test-support). Wiremock
+ * mocks serve them as canned gRPC responses; tests verify them against the
+ * invariants via pipestream-test-support (testImplementation scope).
+ *
+ * <p>Kept inside wiremock-server's own main source on purpose — the wiremock
+ * runtime container has no pipestream-test-support dependency at main scope
+ * and must build its canned responses self-sufficiently.
+ */
+public final class SemanticFixtureBuilder {
+
+    private SemanticFixtureBuilder() {}
+
+    /**
+     * Builds a minimal valid stage-1 {@link PipeDoc} for the chunker step mock's
+     * success scenario. One SPR at source_field="body" with chunk_config_id="sentence_v1",
+     * empty embedding_config_id (placeholder), one chunk with empty vector,
+     * directive_key stamped in metadata, nlp_analysis attached, one matching
+     * source_field_analytics entry.
+     */
+    public static PipeDoc buildStage1PipeDoc() {
+        SemanticChunk chunk = SemanticChunk.newBuilder()
+                .setChunkId("chunk-0")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(ChunkEmbedding.newBuilder()
+                        .setTextContent("The quick brown fox jumps over the lazy dog.")
+                        .setOriginalCharStartOffset(0)
+                        .setOriginalCharEndOffset(44)
+                        .build())
+                .build();
+
+        SemanticProcessingResult spr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage1:fixture-doc-001:body:sentence_v1:")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("")
+                .addChunks(chunk)
+                .putMetadata("directive_key", Value.newBuilder()
+                        .setStringValue("sha256b64url-fixture-directive-001").build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                .addSourceFieldAnalytics(SourceFieldAnalytics.newBuilder()
+                        .setSourceField("body")
+                        .setChunkConfigId("sentence_v1")
+                        .build())
+                .build();
+
+        return PipeDoc.newBuilder()
+                .setDocId("fixture-doc-001")
+                .setSearchMetadata(sm)
+                .build();
+    }
+
+    /**
+     * Builds a minimal valid stage-2 {@link PipeDoc} for the embedder step mock's
+     * success scenario. Same shape as stage 1 but with embedding_config_id="minilm"
+     * and a populated 4-element deterministic vector on the chunk. Includes
+     * vector_set_directives advertising the minilm embedder config so the
+     * assertPostEmbedder cross-check passes.
+     */
+    public static PipeDoc buildStage2PipeDoc() {
+        ChunkEmbedding embedding = ChunkEmbedding.newBuilder()
+                .setTextContent("The quick brown fox jumps over the lazy dog.")
+                .setOriginalCharStartOffset(0)
+                .setOriginalCharEndOffset(44)
+                .addVector(0.1f)
+                .addVector(0.2f)
+                .addVector(0.3f)
+                .addVector(0.4f)
+                .build();
+
+        SemanticChunk chunk = SemanticChunk.newBuilder()
+                .setChunkId("chunk-0")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(embedding)
+                .build();
+
+        SemanticProcessingResult spr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage2:fixture-doc-001:body:sentence_v1:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("minilm")
+                .addChunks(chunk)
+                .putMetadata("directive_key", Value.newBuilder()
+                        .setStringValue("sha256b64url-fixture-directive-001").build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+
+        VectorSetDirectives directives = VectorSetDirectives.newBuilder()
+                .addDirectives(VectorDirective.newBuilder()
+                        .setSourceLabel("body")
+                        .setCelSelector("document.body")
+                        .addEmbedderConfigs(NamedEmbedderConfig.newBuilder()
+                                .setConfigId("minilm")
+                                .build())
+                        .build())
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                .addSourceFieldAnalytics(SourceFieldAnalytics.newBuilder()
+                        .setSourceField("body")
+                        .setChunkConfigId("sentence_v1")
+                        .build())
+                .setVectorSetDirectives(directives)
+                .build();
+
+        return PipeDoc.newBuilder()
+                .setDocId("fixture-doc-001")
+                .setSearchMetadata(sm)
+                .build();
+    }
+
+    /**
+     * Builds a minimal valid stage-3 {@link PipeDoc} for the semantic-graph step
+     * mock's success scenario. Contains the stage-2 SPR plus an appended
+     * document-centroid SPR and a semantic-boundary SPR, all lex-sorted on
+     * (source_field, chunk_config_id, embedding_config_id, result_id).
+     *
+     * <p>At source_field="body", chunk_config_ids sort as:
+     * {@code document_centroid < semantic < sentence_v1}. The result list is
+     * ordered accordingly.
+     */
+    public static PipeDoc buildStage3PipeDoc() {
+        ChunkEmbedding stage2Embedding = ChunkEmbedding.newBuilder()
+                .setTextContent("The quick brown fox jumps over the lazy dog.")
+                .setOriginalCharStartOffset(0)
+                .setOriginalCharEndOffset(44)
+                .addVector(0.1f).addVector(0.2f).addVector(0.3f).addVector(0.4f)
+                .build();
+
+        SemanticChunk stage2Chunk = SemanticChunk.newBuilder()
+                .setChunkId("chunk-0")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(stage2Embedding)
+                .build();
+
+        SemanticProcessingResult stage2Spr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage2:fixture-doc-001:body:sentence_v1:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("minilm")
+                .addChunks(stage2Chunk)
+                .putMetadata("directive_key", Value.newBuilder()
+                        .setStringValue("sha256b64url-fixture-directive-001").build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+
+        ChunkEmbedding centroidEmbedding = ChunkEmbedding.newBuilder()
+                .setTextContent("Document centroid vector")
+                .setOriginalCharStartOffset(0)
+                .setOriginalCharEndOffset(24)
+                .addVector(0.1f).addVector(0.2f).addVector(0.3f).addVector(0.4f)
+                .build();
+
+        SemanticChunk centroidChunk = SemanticChunk.newBuilder()
+                .setChunkId("centroid-0")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(centroidEmbedding)
+                .build();
+
+        SemanticProcessingResult centroidSpr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:fixture-doc-001:body:document_centroid:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("document_centroid")
+                .setEmbeddingConfigId("minilm")
+                .addChunks(centroidChunk)
+                .putMetadata("directive_key", Value.newBuilder()
+                        .setStringValue("sha256b64url-fixture-directive-001").build())
+                .setCentroidMetadata(CentroidMetadata.newBuilder()
+                        .setGranularity(GranularityLevel.GRANULARITY_LEVEL_DOCUMENT)
+                        .setSourceVectorCount(1)
+                        .build())
+                .build();
+
+        ChunkEmbedding boundaryEmbedding = ChunkEmbedding.newBuilder()
+                .setTextContent("Semantic boundary chunk text")
+                .setOriginalCharStartOffset(0)
+                .setOriginalCharEndOffset(28)
+                .addVector(0.5f).addVector(0.6f).addVector(0.7f).addVector(0.8f)
+                .build();
+
+        SemanticChunk boundaryChunk = SemanticChunk.newBuilder()
+                .setChunkId("semantic-0")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(boundaryEmbedding)
+                .build();
+
+        SemanticProcessingResult boundarySpr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:fixture-doc-001:body:semantic:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("semantic")
+                .setEmbeddingConfigId("minilm")
+                .setGranularity(GranularityLevel.GRANULARITY_LEVEL_SEMANTIC_CHUNK)
+                .setSemanticConfigId("semantic_v1")
+                .addChunks(boundaryChunk)
+                .putMetadata("directive_key", Value.newBuilder()
+                        .setStringValue("sha256b64url-fixture-directive-001").build())
+                .build();
+
+        VectorSetDirectives directives = VectorSetDirectives.newBuilder()
+                .addDirectives(VectorDirective.newBuilder()
+                        .setSourceLabel("body")
+                        .setCelSelector("document.body")
+                        .addEmbedderConfigs(NamedEmbedderConfig.newBuilder()
+                                .setConfigId("minilm")
+                                .build())
+                        .build())
+                .build();
+
+        // lex order on (source_field, chunk_config_id, embedding_config_id, result_id):
+        // body|document_centroid|minilm < body|semantic|minilm < body|sentence_v1|minilm
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(centroidSpr)
+                .addSemanticResults(boundarySpr)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(SourceFieldAnalytics.newBuilder()
+                        .setSourceField("body")
+                        .setChunkConfigId("sentence_v1")
+                        .build())
+                .setVectorSetDirectives(directives)
+                .build();
+
+        return PipeDoc.newBuilder()
+                .setDocId("fixture-doc-001")
+                .setSearchMetadata(sm)
+                .build();
+    }
+}

--- a/src/main/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer
+++ b/src/main/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer
@@ -14,3 +14,4 @@ ai.pipestream.wiremock.client.PipelineConfigServiceMock
 ai.pipestream.wiremock.client.PipelineGraphServiceMock
 ai.pipestream.wiremock.client.DesignModeServiceMock
 ai.pipestream.wiremock.client.ValidationServiceMock
+ai.pipestream.wiremock.client.ChunkerStepMock

--- a/src/main/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer
+++ b/src/main/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer
@@ -15,3 +15,5 @@ ai.pipestream.wiremock.client.PipelineGraphServiceMock
 ai.pipestream.wiremock.client.DesignModeServiceMock
 ai.pipestream.wiremock.client.ValidationServiceMock
 ai.pipestream.wiremock.client.ChunkerStepMock
+ai.pipestream.wiremock.client.EmbedderStepMock
+ai.pipestream.wiremock.client.SemanticGraphStepMock

--- a/src/test/java/ai/pipestream/wiremock/client/ChunkerStepMockTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/ChunkerStepMockTest.java
@@ -1,0 +1,91 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataRequest;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.wiremock.grpc.GrpcExtensionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link ChunkerStepMock}. Verifies the mock responds correctly when
+ * a gRPC {@code ProcessData} request arrives with {@code x-module-name: chunker}
+ * metadata and that the returned {@link PipeDoc} passes
+ * {@link SemanticPipelineInvariants#assertPostChunker(PipeDoc)}.
+ */
+class ChunkerStepMockTest {
+
+    private static WireMockServer wireMockServer;
+    private static ManagedChannel channel;
+
+    @BeforeAll
+    static void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort()
+                .extensions(new GrpcExtensionFactory())
+                .withRootDirectory("build/resources/test/wiremock"));
+        wireMockServer.start();
+
+        WireMock wireMock = new WireMock(wireMockServer.port());
+        new ChunkerStepMock().initializeDefaults(wireMock);
+
+        channel = ManagedChannelBuilder.forAddress("localhost", wireMockServer.port())
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void successScenarioReturnsStage1PipeDocPassingAssertPostChunker() {
+        PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stub =
+                stubWithModuleHeader("chunker");
+
+        ProcessDataResponse response = stub.processData(
+                ProcessDataRequest.newBuilder().build());
+
+        assertThat(response.getOutcome())
+                .as("chunker step mock success scenario should return PROCESSING_OUTCOME_SUCCESS")
+                .isEqualTo(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS);
+
+        assertThat(response.hasOutputDoc())
+                .as("chunker step mock success scenario should include output_doc")
+                .isTrue();
+
+        PipeDoc outputDoc = response.getOutputDoc();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostChunker(outputDoc))
+                .as("chunker step mock success response must satisfy SemanticPipelineInvariants.assertPostChunker")
+                .doesNotThrowAnyException();
+    }
+
+    private PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stubWithModuleHeader(
+            String moduleName) {
+        Metadata md = new Metadata();
+        md.put(Metadata.Key.of("x-module-name", Metadata.ASCII_STRING_MARSHALLER), moduleName);
+        return PipeStepProcessorServiceGrpc.newBlockingStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+    }
+}

--- a/src/test/java/ai/pipestream/wiremock/client/EmbedderStepMockTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/EmbedderStepMockTest.java
@@ -1,0 +1,91 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataRequest;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.wiremock.grpc.GrpcExtensionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link EmbedderStepMock}. Verifies the mock responds correctly when
+ * a gRPC {@code ProcessData} request arrives with {@code x-module-name: embedder}
+ * metadata and that the returned {@link PipeDoc} passes
+ * {@link SemanticPipelineInvariants#assertPostEmbedder(PipeDoc)}.
+ */
+class EmbedderStepMockTest {
+
+    private static WireMockServer wireMockServer;
+    private static ManagedChannel channel;
+
+    @BeforeAll
+    static void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort()
+                .extensions(new GrpcExtensionFactory())
+                .withRootDirectory("build/resources/test/wiremock"));
+        wireMockServer.start();
+
+        WireMock wireMock = new WireMock(wireMockServer.port());
+        new EmbedderStepMock().initializeDefaults(wireMock);
+
+        channel = ManagedChannelBuilder.forAddress("localhost", wireMockServer.port())
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void successScenarioReturnsStage2PipeDocPassingAssertPostEmbedder() {
+        PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stub =
+                stubWithModuleHeader("embedder");
+
+        ProcessDataResponse response = stub.processData(
+                ProcessDataRequest.newBuilder().build());
+
+        assertThat(response.getOutcome())
+                .as("embedder step mock success scenario should return PROCESSING_OUTCOME_SUCCESS")
+                .isEqualTo(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS);
+
+        assertThat(response.hasOutputDoc())
+                .as("embedder step mock success scenario should include output_doc")
+                .isTrue();
+
+        PipeDoc outputDoc = response.getOutputDoc();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostEmbedder(outputDoc))
+                .as("embedder step mock success response must satisfy SemanticPipelineInvariants.assertPostEmbedder")
+                .doesNotThrowAnyException();
+    }
+
+    private PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stubWithModuleHeader(
+            String moduleName) {
+        Metadata md = new Metadata();
+        md.put(Metadata.Key.of("x-module-name", Metadata.ASCII_STRING_MARSHALLER), moduleName);
+        return PipeStepProcessorServiceGrpc.newBlockingStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+    }
+}

--- a/src/test/java/ai/pipestream/wiremock/client/SemanticGraphStepMockTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/SemanticGraphStepMockTest.java
@@ -1,0 +1,92 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataRequest;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.wiremock.grpc.GrpcExtensionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link SemanticGraphStepMock}. Verifies the mock responds correctly
+ * when a gRPC {@code ProcessData} request arrives with
+ * {@code x-module-name: semantic-graph} metadata and that the returned
+ * {@link PipeDoc} passes
+ * {@link SemanticPipelineInvariants#assertPostSemanticGraph(PipeDoc)}.
+ */
+class SemanticGraphStepMockTest {
+
+    private static WireMockServer wireMockServer;
+    private static ManagedChannel channel;
+
+    @BeforeAll
+    static void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort()
+                .extensions(new GrpcExtensionFactory())
+                .withRootDirectory("build/resources/test/wiremock"));
+        wireMockServer.start();
+
+        WireMock wireMock = new WireMock(wireMockServer.port());
+        new SemanticGraphStepMock().initializeDefaults(wireMock);
+
+        channel = ManagedChannelBuilder.forAddress("localhost", wireMockServer.port())
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void successScenarioReturnsStage3PipeDocPassingAssertPostSemanticGraph() {
+        PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stub =
+                stubWithModuleHeader("semantic-graph");
+
+        ProcessDataResponse response = stub.processData(
+                ProcessDataRequest.newBuilder().build());
+
+        assertThat(response.getOutcome())
+                .as("semantic-graph step mock success scenario should return PROCESSING_OUTCOME_SUCCESS")
+                .isEqualTo(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS);
+
+        assertThat(response.hasOutputDoc())
+                .as("semantic-graph step mock success scenario should include output_doc")
+                .isTrue();
+
+        PipeDoc outputDoc = response.getOutputDoc();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostSemanticGraph(outputDoc))
+                .as("semantic-graph step mock success response must satisfy SemanticPipelineInvariants.assertPostSemanticGraph")
+                .doesNotThrowAnyException();
+    }
+
+    private PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stubWithModuleHeader(
+            String moduleName) {
+        Metadata md = new Metadata();
+        md.put(Metadata.Key.of("x-module-name", Metadata.ASCII_STRING_MARSHALLER), moduleName);
+        return PipeStepProcessorServiceGrpc.newBlockingStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+    }
+}

--- a/src/test/java/ai/pipestream/wiremock/client/SemanticPipelineShowcaseTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/SemanticPipelineShowcaseTest.java
@@ -1,0 +1,167 @@
+package ai.pipestream.wiremock.client;
+
+import ai.pipestream.data.module.v1.PipeStepProcessorServiceGrpc;
+import ai.pipestream.data.module.v1.ProcessDataRequest;
+import ai.pipestream.data.module.v1.ProcessDataResponse;
+import ai.pipestream.data.module.v1.ProcessingOutcome;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.wiremock.grpc.GrpcExtensionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * End-to-end contract-lock showcase for the three semantic pipeline step mocks.
+ *
+ * <p>This test exercises the full chunker → embedder → semantic-graph path
+ * by sending three consecutive {@code ProcessData} gRPC calls against a single
+ * WireMock server, switching only the {@code x-module-name} gRPC metadata
+ * header between calls. Each response is validated against its corresponding
+ * stage invariant from {@code pipestream-test-support}.
+ *
+ * <h2>What this test proves</h2>
+ * <ul>
+ *   <li>{@link ChunkerStepMock}, {@link EmbedderStepMock}, and
+ *       {@link SemanticGraphStepMock} can coexist in the same WireMock server
+ *       without stub collisions (each is scoped by a distinct
+ *       {@code x-module-name} value).</li>
+ *   <li>Each mock's canned response passes its corresponding
+ *       {@code SemanticPipelineInvariants.assertPost*} method, which is the
+ *       contract lock used by the three real module refactors in Phase 3.</li>
+ *   <li>The three stage fixtures built by {@link
+ *       ai.pipestream.wiremock.client.semantic.SemanticFixtureBuilder} form a
+ *       coherent shape chain (stage 0 → stage 1 → stage 2 → stage 3).</li>
+ * </ul>
+ *
+ * <h2>What this test does NOT prove</h2>
+ * <ul>
+ *   <li>That the real {@code module-chunker}, {@code module-embedder}, and
+ *       {@code module-semantic-graph} produce those fixtures. Each module's
+ *       own unit tests (R1/R2/R3) prove that.</li>
+ *   <li>That the real pipeline works end-to-end. That's the
+ *       {@code module-testing-sidecar} R5 verification step.</li>
+ * </ul>
+ */
+public class SemanticPipelineShowcaseTest {
+
+    private static WireMockServer wireMockServer;
+    private static ManagedChannel channel;
+
+    @BeforeAll
+    static void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort()
+                .extensions(new GrpcExtensionFactory())
+                .withRootDirectory("build/resources/test/wiremock"));
+        wireMockServer.start();
+
+        WireMock wireMock = new WireMock(wireMockServer.port());
+        new ChunkerStepMock().initializeDefaults(wireMock);
+        new EmbedderStepMock().initializeDefaults(wireMock);
+        new SemanticGraphStepMock().initializeDefaults(wireMock);
+
+        channel = ManagedChannelBuilder.forAddress("localhost", wireMockServer.port())
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void semanticPipelineRoundTripPassesAllThreeInvariants() {
+        // Stage 1: chunker
+        PipeDoc stage1 = callProcessData("chunker");
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostChunker(stage1))
+                .as("chunker step mock response must satisfy assertPostChunker")
+                .doesNotThrowAnyException();
+
+        // Stage 2: embedder (the mock returns its canned fixture regardless of
+        // the input, so passing stage1 or an empty request produces the same
+        // output. The round-trip's purpose is mock wiring + fixture coherence,
+        // not a real pipeline.)
+        PipeDoc stage2 = callProcessData("embedder");
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostEmbedder(stage2))
+                .as("embedder step mock response must satisfy assertPostEmbedder")
+                .doesNotThrowAnyException();
+
+        // Stage 3: semantic-graph
+        PipeDoc stage3 = callProcessData("semantic-graph");
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostSemanticGraph(stage3))
+                .as("semantic-graph step mock response must satisfy assertPostSemanticGraph")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void semanticPipelineShapeChainIsCoherent() {
+        // Verify the three stages' SPRs form a coherent chain: the SPR at
+        // source_field="body", chunk_config_id="sentence_v1" should exist at
+        // every stage, with the embedding_config_id transitioning from empty
+        // (stage 1) to populated (stage 2+).
+        PipeDoc stage1 = callProcessData("chunker");
+        PipeDoc stage2 = callProcessData("embedder");
+        PipeDoc stage3 = callProcessData("semantic-graph");
+
+        // Stage 1: one SPR, embedding_config_id empty
+        assertThat(stage1.getSearchMetadata().getSemanticResultsCount())
+                .as("stage 1 fixture should have one SPR")
+                .isEqualTo(1);
+        assertThat(stage1.getSearchMetadata().getSemanticResults(0).getEmbeddingConfigId())
+                .as("stage 1 SPR embedding_config_id must be empty (placeholder)")
+                .isEmpty();
+
+        // Stage 2: one SPR, embedding_config_id populated
+        assertThat(stage2.getSearchMetadata().getSemanticResultsCount())
+                .as("stage 2 fixture should have one SPR")
+                .isEqualTo(1);
+        assertThat(stage2.getSearchMetadata().getSemanticResults(0).getEmbeddingConfigId())
+                .as("stage 2 SPR embedding_config_id must be populated")
+                .isEqualTo("minilm");
+
+        // Stage 3: three SPRs (stage-2 preserved + centroid + boundary)
+        assertThat(stage3.getSearchMetadata().getSemanticResultsCount())
+                .as("stage 3 fixture should have three SPRs (preserved stage-2 + centroid + boundary)")
+                .isEqualTo(3);
+    }
+
+    private PipeDoc callProcessData(String moduleName) {
+        Metadata md = new Metadata();
+        md.put(Metadata.Key.of("x-module-name", Metadata.ASCII_STRING_MARSHALLER), moduleName);
+        PipeStepProcessorServiceGrpc.PipeStepProcessorServiceBlockingStub stub =
+                PipeStepProcessorServiceGrpc.newBlockingStub(channel)
+                        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+
+        ProcessDataResponse response = stub.processData(
+                ProcessDataRequest.newBuilder().build());
+
+        assertThat(response.getOutcome())
+                .as("%s step mock should return PROCESSING_OUTCOME_SUCCESS", moduleName)
+                .isEqualTo(ProcessingOutcome.PROCESSING_OUTCOME_SUCCESS);
+        assertThat(response.hasOutputDoc())
+                .as("%s step mock should include output_doc", moduleName)
+                .isTrue();
+
+        return response.getOutputDoc();
+    }
+}

--- a/src/test/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer
+++ b/src/test/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer
@@ -8,3 +8,12 @@ ai.pipestream.wiremock.client.FilesystemServiceMock
 ai.pipestream.wiremock.client.PipeDocServiceMock
 ai.pipestream.wiremock.client.EngineV1ServiceMock
 ai.pipestream.wiremock.client.OpenSearchManagerMock
+ai.pipestream.wiremock.client.BackendEndpointServiceMock
+ai.pipestream.wiremock.client.ConnectorIntakeServiceMock
+ai.pipestream.wiremock.client.PipelineConfigServiceMock
+ai.pipestream.wiremock.client.PipelineGraphServiceMock
+ai.pipestream.wiremock.client.DesignModeServiceMock
+ai.pipestream.wiremock.client.ValidationServiceMock
+ai.pipestream.wiremock.client.ChunkerStepMock
+ai.pipestream.wiremock.client.EmbedderStepMock
+ai.pipestream.wiremock.client.SemanticGraphStepMock


### PR DESCRIPTION
## Summary

Adds three new header-scoped wiremock step mocks that complete Phase 1 contract-lock work for the semantic pipeline refactor (DESIGN.md §5 / ROLLOUT.md §6 / PLAN.md §P1c–P1d). They serve as gRPC test doubles for the three real modules that get refactored in Phase 3 (\`module-chunker\`, \`module-embedder\`, \`module-semantic-graph\`), so those modules can run integration tests against canonical stage fixtures without requiring the other two modules to be running.

- **\`ChunkerStepMock\`** — scoped on \`x-module-name: chunker\`, returns a canned stage-1 \`PipeDoc\` that satisfies \`SemanticPipelineInvariants.assertPostChunker\`.
- **\`EmbedderStepMock\`** — scoped on \`x-module-name: embedder\`, returns a canned stage-2 \`PipeDoc\` that satisfies \`SemanticPipelineInvariants.assertPostEmbedder\`.
- **\`SemanticGraphStepMock\`** — scoped on \`x-module-name: semantic-graph\`, returns a canned stage-3 \`PipeDoc\` that satisfies \`SemanticPipelineInvariants.assertPostSemanticGraph\`.

All three are registered via ServiceLoader in \`META-INF/services\` and coexist with the existing \`PipeStepProcessorMock\` (which handles \`GetServiceRegistration\` and the catchall \`ProcessData\` stub). Each new mock registers at wiremock priority 1 (above the catchall) via the low-level HTTP API with \`withHeader(\"x-module-name\", equalTo(...))\`.

This is **happy-path only** for now. Failure / partial / slow scenarios will land in follow-up commits as Phase 3 module agents need them.

## What's in this PR

Four commits:

1. \`f09865e\` — \`ChunkerStepMock\` + \`SemanticFixtureBuilder\` + \`ChunkerStepMockTest\` + build.gradle \`testImplementation\` on \`ai.pipestream:pipestream-test-support:0.7.24-SNAPSHOT\` (non-transitive — wiremock is not a Quarkus project and doesn't want the transitive testcontainers/Quarkus bloat).
2. \`ea2e67a\` — \`EmbedderStepMock\` + \`SemanticGraphStepMock\` + their tests + \`META-INF\` registration.
3. \`caeeb82\` — \`SemanticPipelineShowcaseTest\` — end-to-end round-trip test that exercises all three mocks in sequence via \`x-module-name\` headers and asserts each stage output against its invariant.

### New files

- \`src/main/java/ai/pipestream/wiremock/client/ChunkerStepMock.java\`
- \`src/main/java/ai/pipestream/wiremock/client/EmbedderStepMock.java\`
- \`src/main/java/ai/pipestream/wiremock/client/SemanticGraphStepMock.java\`
- \`src/main/java/ai/pipestream/wiremock/client/semantic/SemanticFixtureBuilder.java\` — programmatic builders for stage-1/2/3 \`PipeDoc\`s, kept inside wiremock's own main source so the runtime container has no \`pipestream-test-support\` dep at main scope.
- \`src/test/java/ai/pipestream/wiremock/client/ChunkerStepMockTest.java\`
- \`src/test/java/ai/pipestream/wiremock/client/EmbedderStepMockTest.java\`
- \`src/test/java/ai/pipestream/wiremock/client/SemanticGraphStepMockTest.java\`
- \`src/test/java/ai/pipestream/wiremock/client/SemanticPipelineShowcaseTest.java\`

### Modified

- \`build.gradle\` — one new \`testImplementation\` dep (non-transitive).
- \`src/main/resources/META-INF/services/ai.pipestream.wiremock.client.ServiceMockInitializer\` — three new entries.

## Test plan

- [x] \`./gradlew test --tests ChunkerStepMockTest\` — PASSED.
- [x] \`./gradlew test --tests EmbedderStepMockTest\` — PASSED.
- [x] \`./gradlew test --tests SemanticGraphStepMockTest\` — PASSED.
- [x] \`./gradlew test --tests SemanticPipelineShowcaseTest\` — 2/2 PASSED (\`semanticPipelineRoundTripPassesAllThreeInvariants\` + \`semanticPipelineShapeChainIsCoherent\`).
- [x] Full wiremock test suite: \`./gradlew test\` — **243 tests, 0 failures, 0 errors, 0 skipped.** No regressions on existing mocks.
- [ ] Reviewer to confirm the four new test classes use AssertJ with descriptive \`.as()\` messages consistently (per \`feedback-assertj-preference.md\` — mandatory project rule).

## Related

- \`ai-pipestream/pipestream-platform#51\` — \`SemanticPipelineInvariants\` in \`pipestream-test-support\` (merged). This PR depends on it being published at \`0.7.24-SNAPSHOT\` or later.
- \`ai-pipestream/pipestream-protos#37\` — ROLLOUT.md / PLAN.md / DESIGN.md §14 (merged).

## Notes

- wiremock-server has no \`pipestream-test-support\` dep at main scope. The runtime container ships only its own \`SemanticFixtureBuilder\` (no AssertJ, no Quarkus, no testcontainers). Tests get \`SemanticPipelineInvariants\` via a non-transitive \`testImplementation\` dep.
- After this PR merges and wiremock publishes its next SNAPSHOT, the three semantic-pipeline Phase 3 agents (R1/R2/R3) will use it as a testcontainer to verify their own \`processData\` outputs satisfy the downstream stage invariants.