### PR TITLE
refactor(test): inline SemanticPipelineInvariants into wiremock-server test sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,14 +101,6 @@ dependencies {
     testImplementation libs.junit.jupiter
     testImplementation libs.assertj.core
     testRuntimeOnly libs.junit.platform.launcher
-
-    // pipestream-test-support provides SemanticPipelineInvariants for the
-    // semantic-pipeline step mock tests. Non-transitive: wiremock-server is
-    // not a Quarkus project, so we only want the thin class set from the jar,
-    // not the transitive Quarkus / testcontainers deps.
-    testImplementation('ai.pipestream:pipestream-test-support:0.7.24-SNAPSHOT') {
-        transitive = false
-    }
 }
 
 // Configure source sets for proto-toolchain generated code

--- a/src/main/java/ai/pipestream/wiremock/client/semantic/SemanticFixtureBuilder.java
+++ b/src/main/java/ai/pipestream/wiremock/client/semantic/SemanticFixtureBuilder.java
@@ -19,13 +19,13 @@ import com.google.protobuf.Value;
  * semantic pipeline step mocks.
  *
  * <p>These builders produce the exact shapes required by the invariants defined
- * in {@code SemanticPipelineInvariants} (in pipestream-test-support). Wiremock
- * mocks serve them as canned gRPC responses; tests verify them against the
- * invariants via pipestream-test-support (testImplementation scope).
+ * in {@code ai.pipestream.wiremock.client.semantic.SemanticPipelineInvariants}
+ * (test sources). Wiremock mocks serve them as canned gRPC responses; tests
+ * verify them against the invariants directly.
  *
  * <p>Kept inside wiremock-server's own main source on purpose — the wiremock
- * runtime container has no pipestream-test-support dependency at main scope
- * and must build its canned responses self-sufficiently.
+ * runtime container must build its canned responses self-sufficiently and
+ * cannot depend on test sources.
  */
 public final class SemanticFixtureBuilder {
 

--- a/src/test/java/ai/pipestream/wiremock/client/ChunkerStepMockTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/ChunkerStepMockTest.java
@@ -5,7 +5,7 @@ import ai.pipestream.data.module.v1.ProcessDataRequest;
 import ai.pipestream.data.module.v1.ProcessDataResponse;
 import ai.pipestream.data.module.v1.ProcessingOutcome;
 import ai.pipestream.data.v1.PipeDoc;
-import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import ai.pipestream.wiremock.client.semantic.SemanticPipelineInvariants;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;

--- a/src/test/java/ai/pipestream/wiremock/client/EmbedderStepMockTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/EmbedderStepMockTest.java
@@ -5,7 +5,7 @@ import ai.pipestream.data.module.v1.ProcessDataRequest;
 import ai.pipestream.data.module.v1.ProcessDataResponse;
 import ai.pipestream.data.module.v1.ProcessingOutcome;
 import ai.pipestream.data.v1.PipeDoc;
-import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import ai.pipestream.wiremock.client.semantic.SemanticPipelineInvariants;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;

--- a/src/test/java/ai/pipestream/wiremock/client/SemanticGraphStepMockTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/SemanticGraphStepMockTest.java
@@ -5,7 +5,7 @@ import ai.pipestream.data.module.v1.ProcessDataRequest;
 import ai.pipestream.data.module.v1.ProcessDataResponse;
 import ai.pipestream.data.module.v1.ProcessingOutcome;
 import ai.pipestream.data.v1.PipeDoc;
-import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import ai.pipestream.wiremock.client.semantic.SemanticPipelineInvariants;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;

--- a/src/test/java/ai/pipestream/wiremock/client/SemanticPipelineShowcaseTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/SemanticPipelineShowcaseTest.java
@@ -5,7 +5,7 @@ import ai.pipestream.data.module.v1.ProcessDataRequest;
 import ai.pipestream.data.module.v1.ProcessDataResponse;
 import ai.pipestream.data.module.v1.ProcessingOutcome;
 import ai.pipestream.data.v1.PipeDoc;
-import ai.pipestream.test.support.semantic.SemanticPipelineInvariants;
+import ai.pipestream.wiremock.client.semantic.SemanticPipelineInvariants;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;

--- a/src/test/java/ai/pipestream/wiremock/client/semantic/SemanticPipelineInvariants.java
+++ b/src/test/java/ai/pipestream/wiremock/client/semantic/SemanticPipelineInvariants.java
@@ -1,0 +1,640 @@
+package ai.pipestream.wiremock.client.semantic;
+
+import ai.pipestream.data.v1.CentroidMetadata;
+import ai.pipestream.data.v1.ChunkEmbedding;
+import ai.pipestream.data.v1.GranularityLevel;
+import ai.pipestream.data.v1.NamedEmbedderConfig;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.data.v1.SearchMetadata;
+import ai.pipestream.data.v1.SemanticChunk;
+import ai.pipestream.data.v1.SemanticProcessingResult;
+import ai.pipestream.data.v1.VectorDirective;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Stage invariants for the three-step semantic pipeline (see
+ * pipestream-protos/docs/semantic-pipeline/DESIGN.md §5).
+ *
+ * <p>Owned by pipestream-wiremock-server for the semantic step mock tests
+ * ({@code ChunkerStepMockTest}, {@code EmbedderStepMockTest},
+ * {@code SemanticGraphStepMockTest}, {@code SemanticPipelineShowcaseTest}).
+ *
+ * <p>Not shared via a library. Each of the semantic-pipeline module consumers
+ * (module-chunker, module-embedder, module-semantic-graph) inlines its own
+ * per-module copy of the post-stage invariants into its test sources — see
+ * each module's {@code *StepInvariantsTest} or integration test. This avoids
+ * the classloader hazard of bundling proto-aware assertion helpers into a
+ * Quarkus extension jar, and is the explicit inline-per-consumer pattern the
+ * repo uses for semantic-pipeline test code.
+ */
+public final class SemanticPipelineInvariants {
+
+    /**
+     * Default cap on the number of semantic-boundary chunks a semantic-graph
+     * step may emit per doc, per DESIGN.md §6.3 {@code max_semantic_chunks_per_doc}.
+     * The production step can override this via config; the invariant only
+     * checks the default. Module tests that use a non-default config should
+     * perform their own cap check.
+     */
+    public static final int MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT = 50;
+
+    private SemanticPipelineInvariants() {}
+
+    /**
+     * Asserts that the given {@code doc} satisfies the post-chunker stage invariant
+     * as defined in DESIGN.md §5.1 and §21.2.
+     *
+     * <p>Checks performed:
+     * <ol>
+     *   <li>{@code search_metadata} is set on the doc.</li>
+     *   <li>For every {@code SemanticProcessingResult} in {@code semantic_results}:
+     *     <ul>
+     *       <li>{@code embedding_config_id} is empty (placeholder, not yet embedded).</li>
+     *       <li>{@code source_field_name} is non-empty.</li>
+     *       <li>{@code chunk_config_id} is non-empty.</li>
+     *       <li>{@code chunks} is non-empty.</li>
+     *       <li>For every {@code SemanticChunk}:
+     *         <ul>
+     *           <li>{@code embedding_info.text_content} is non-empty.</li>
+     *           <li>{@code embedding_info.vector} is empty (not yet embedded).</li>
+     *           <li>{@code chunk_id} is non-empty.</li>
+     *           <li>{@code original_char_start_offset} is non-negative.</li>
+     *           <li>{@code original_char_end_offset} >= {@code original_char_start_offset}.</li>
+     *         </ul>
+     *       </li>
+     *       <li>{@code metadata} contains a {@code "directive_key"} entry (per §21.2).</li>
+     *     </ul>
+     *   </li>
+     *   <li>For every unique {@code source_field_name} appearing in {@code semantic_results},
+     *       at least one SPR with that source_field_name has {@code nlp_analysis} set
+     *       (per DESIGN.md §5.1).</li>
+     *   <li>{@code search_metadata.source_field_analytics[]} contains one entry per unique
+     *       {@code (source_field, chunk_config_id)} pair present in {@code semantic_results}
+     *       (per DESIGN.md §5.1).</li>
+     *   <li>{@code semantic_results[]} is lex-sorted by
+     *       {@code (source_field_name, chunk_config_id, embedding_config_id, result_id)}.</li>
+     * </ol>
+     *
+     * <p>Note: an empty {@code semantic_results[]} is valid per DESIGN.md §5.1 when the
+     * doc contained no source text matching any active directive. This method does not
+     * enforce non-empty {@code semantic_results[]}; that check is the caller's
+     * responsibility when it matters.
+     *
+     * @param doc the PipeDoc to validate
+     * @throws AssertionError if any invariant is violated
+     */
+    public static void assertPostChunker(PipeDoc doc) {
+        assertThat(doc.hasSearchMetadata())
+                .as("post-chunker: search_metadata must be set on the PipeDoc")
+                .isTrue();
+
+        SearchMetadata sm = doc.getSearchMetadata();
+        List<SemanticProcessingResult> results = sm.getSemanticResultsList();
+
+        for (int i = 0; i < results.size(); i++) {
+            SemanticProcessingResult spr = results.get(i);
+            String sprContext = "post-chunker: semantic_results[" + i + "]"
+                    + " (source_field_name='" + spr.getSourceFieldName()
+                    + "', chunk_config_id='" + spr.getChunkConfigId()
+                    + "', result_id='" + spr.getResultId() + "')";
+
+            assertThat(spr.getEmbeddingConfigId())
+                    .as(sprContext + ": embedding_config_id must be empty (placeholder SPR — not yet embedded)")
+                    .isEmpty();
+
+            assertThat(spr.getSourceFieldName())
+                    .as(sprContext + ": source_field_name must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getChunkConfigId())
+                    .as(sprContext + ": chunk_config_id must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getChunksList())
+                    .as(sprContext + ": chunks must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getMetadataMap())
+                    .as(sprContext + ": metadata must contain 'directive_key' entry (per DESIGN.md §21.2)")
+                    .containsKey("directive_key");
+
+            List<SemanticChunk> chunks = spr.getChunksList();
+            for (int j = 0; j < chunks.size(); j++) {
+                SemanticChunk chunk = chunks.get(j);
+                String chunkContext = sprContext + " chunk[" + j + "] (chunk_id='" + chunk.getChunkId() + "')";
+
+                ChunkEmbedding embeddingInfo = chunk.getEmbeddingInfo();
+
+                assertThat(embeddingInfo.getTextContent())
+                        .as(chunkContext + ": embedding_info.text_content must be non-empty")
+                        .isNotEmpty();
+
+                assertThat(embeddingInfo.getVectorList())
+                        .as(chunkContext + ": embedding_info.vector must be empty (chunk not yet embedded)")
+                        .isEmpty();
+
+                assertThat(chunk.getChunkId())
+                        .as(chunkContext + ": chunk_id must be non-empty (deterministic ID required per §21.5)")
+                        .isNotEmpty();
+
+                int startOffset = embeddingInfo.hasOriginalCharStartOffset()
+                        ? embeddingInfo.getOriginalCharStartOffset()
+                        : 0;
+                int endOffset = embeddingInfo.hasOriginalCharEndOffset()
+                        ? embeddingInfo.getOriginalCharEndOffset()
+                        : 0;
+
+                assertThat(startOffset)
+                        .as(chunkContext + ": embedding_info.original_char_start_offset must be >= 0")
+                        .isGreaterThanOrEqualTo(0);
+
+                assertThat(endOffset)
+                        .as(chunkContext + ": embedding_info.original_char_end_offset must be >= original_char_start_offset")
+                        .isGreaterThanOrEqualTo(startOffset);
+            }
+        }
+
+        // §5.1: for every unique source_field_name in semantic_results,
+        // at least one SPR with that source_field_name must have nlp_analysis set.
+        Set<String> sourceFieldsInResults = results.stream()
+                .map(SemanticProcessingResult::getSourceFieldName)
+                .collect(Collectors.toSet());
+
+        for (String sourceField : sourceFieldsInResults) {
+            boolean hasNlpForSource = results.stream()
+                    .filter(spr -> sourceField.equals(spr.getSourceFieldName()))
+                    .anyMatch(SemanticProcessingResult::hasNlpAnalysis);
+            assertThat(hasNlpForSource)
+                    .as("post-chunker: at least one SPR with source_field_name='%s' "
+                            + "must have nlp_analysis set (per DESIGN.md §5.1)", sourceField)
+                    .isTrue();
+        }
+
+        // §5.1: source_field_analytics[] must contain an entry per unique
+        // (source_field, chunk_config_id) pair present in semantic_results.
+        Set<String> pairsInResults = results.stream()
+                .map(spr -> spr.getSourceFieldName() + "|" + spr.getChunkConfigId())
+                .collect(Collectors.toSet());
+
+        Set<String> pairsInAnalytics = sm.getSourceFieldAnalyticsList().stream()
+                .map(sfa -> sfa.getSourceField() + "|" + sfa.getChunkConfigId())
+                .collect(Collectors.toSet());
+
+        for (String pair : pairsInResults) {
+            assertThat(pairsInAnalytics)
+                    .as("post-chunker: source_field_analytics[] must contain an entry for "
+                            + "(source_field, chunk_config_id)='%s' (per DESIGN.md §5.1)", pair)
+                    .contains(pair);
+        }
+
+        assertLexSorted(sm, "post-chunker");
+    }
+
+    /**
+     * Asserts that the given {@code doc} satisfies the post-embedder stage invariant
+     * as defined in DESIGN.md §5.2.
+     *
+     * <p>Checks performed:
+     * <ol>
+     *   <li>{@code search_metadata} is set on the doc.</li>
+     *   <li>For every {@code SemanticProcessingResult} in {@code semantic_results}:
+     *     <ul>
+     *       <li>{@code embedding_config_id} is non-empty (SPR is fully embedded, not a placeholder).</li>
+     *       <li>{@code source_field_name} is non-empty.</li>
+     *       <li>{@code chunk_config_id} is non-empty.</li>
+     *       <li>{@code chunks} is non-empty.</li>
+     *       <li>For every {@code SemanticChunk}:
+     *         <ul>
+     *           <li>{@code embedding_info.text_content} is non-empty (preserved from stage 1).</li>
+     *           <li>{@code embedding_info.vector} is non-empty (chunk is embedded).</li>
+     *           <li>{@code chunk_id} is non-empty (preserved from stage 1).</li>
+     *           <li>{@code original_char_start_offset} is non-negative.</li>
+     *           <li>{@code original_char_end_offset} &gt;= {@code original_char_start_offset}.</li>
+     *         </ul>
+     *       </li>
+     *       <li>{@code metadata} contains a {@code "directive_key"} entry (preserved from stage 1 per §21.2).</li>
+     *       <li>If {@code search_metadata.vector_set_directives} is still present on the doc,
+     *           the SPR's {@code embedding_config_id} matches some {@code NamedEmbedderConfig.config_id}
+     *           advertised in those directives.</li>
+     *     </ul>
+     *   </li>
+     *   <li>Zero SPRs with {@code embedding_config_id == ""} (implied by the per-SPR check above).</li>
+     *   <li>For every unique {@code source_field_name} appearing in {@code semantic_results},
+     *       at least one SPR with that source_field_name has {@code nlp_analysis} set
+     *       (preserved from stage 1).</li>
+     *   <li>{@code search_metadata.source_field_analytics[]} contains one entry per unique
+     *       {@code (source_field, chunk_config_id)} pair present in {@code semantic_results}
+     *       (preserved from stage 1).</li>
+     *   <li>{@code semantic_results[]} is lex-sorted.</li>
+     * </ol>
+     *
+     * <p>Note: byte-identity of {@code chunk_id}, {@code text_content}, offsets, and
+     * {@code chunk_analytics} relative to stage 1 (as required by DESIGN.md §5.2) cannot
+     * be checked without the stage 1 doc as input. Callers that need byte-identity must
+     * diff their own stage-1 input against the stage-2 output they are validating.
+     *
+     * <p>Note: an empty {@code semantic_results[]} is valid per DESIGN.md §5.2 when the
+     * doc contained no source text matching any active directive. This method does not
+     * enforce non-empty {@code semantic_results[]}.
+     *
+     * @param doc the PipeDoc to validate
+     * @throws AssertionError if any invariant is violated
+     */
+    public static void assertPostEmbedder(PipeDoc doc) {
+        assertThat(doc.hasSearchMetadata())
+                .as("post-embedder: search_metadata must be set on the PipeDoc")
+                .isTrue();
+
+        SearchMetadata sm = doc.getSearchMetadata();
+        List<SemanticProcessingResult> results = sm.getSemanticResultsList();
+
+        // Collect all NamedEmbedderConfig.config_id values advertised in
+        // vector_set_directives, so each SPR's embedding_config_id can be
+        // cross-checked. If the doc has no vector_set_directives (e.g. they
+        // were cleared after processing), the cross-check is skipped.
+        Set<String> advertisedEmbedderConfigIds = Collections.emptySet();
+        if (sm.hasVectorSetDirectives()) {
+            advertisedEmbedderConfigIds = sm.getVectorSetDirectives().getDirectivesList().stream()
+                    .map(VectorDirective::getEmbedderConfigsList)
+                    .flatMap(List::stream)
+                    .map(NamedEmbedderConfig::getConfigId)
+                    .collect(Collectors.toSet());
+        }
+
+        for (int i = 0; i < results.size(); i++) {
+            SemanticProcessingResult spr = results.get(i);
+            String sprContext = "post-embedder: semantic_results[" + i + "]"
+                    + " (source_field_name='" + spr.getSourceFieldName()
+                    + "', chunk_config_id='" + spr.getChunkConfigId()
+                    + "', embedding_config_id='" + spr.getEmbeddingConfigId()
+                    + "', result_id='" + spr.getResultId() + "')";
+
+            assertThat(spr.getEmbeddingConfigId())
+                    .as(sprContext + ": embedding_config_id must be non-empty (SPR must be fully embedded at stage 2)")
+                    .isNotEmpty();
+
+            assertThat(spr.getSourceFieldName())
+                    .as(sprContext + ": source_field_name must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getChunkConfigId())
+                    .as(sprContext + ": chunk_config_id must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getChunksList())
+                    .as(sprContext + ": chunks must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getMetadataMap())
+                    .as(sprContext + ": metadata must contain 'directive_key' entry (preserved from stage 1 per DESIGN.md §21.2)")
+                    .containsKey("directive_key");
+
+            if (!advertisedEmbedderConfigIds.isEmpty()) {
+                assertThat(advertisedEmbedderConfigIds)
+                        .as(sprContext + ": embedding_config_id must match a NamedEmbedderConfig "
+                                + "advertised in vector_set_directives (per DESIGN.md §5.2)")
+                        .contains(spr.getEmbeddingConfigId());
+            }
+
+            List<SemanticChunk> chunks = spr.getChunksList();
+            for (int j = 0; j < chunks.size(); j++) {
+                SemanticChunk chunk = chunks.get(j);
+                String chunkContext = sprContext + " chunk[" + j + "] (chunk_id='" + chunk.getChunkId() + "')";
+
+                ChunkEmbedding embeddingInfo = chunk.getEmbeddingInfo();
+
+                assertThat(embeddingInfo.getTextContent())
+                        .as(chunkContext + ": embedding_info.text_content must be non-empty (preserved from stage 1)")
+                        .isNotEmpty();
+
+                assertThat(embeddingInfo.getVectorList())
+                        .as(chunkContext + ": embedding_info.vector must be populated at stage 2")
+                        .isNotEmpty();
+
+                assertThat(chunk.getChunkId())
+                        .as(chunkContext + ": chunk_id must be non-empty (preserved from stage 1)")
+                        .isNotEmpty();
+
+                int startOffset = embeddingInfo.hasOriginalCharStartOffset()
+                        ? embeddingInfo.getOriginalCharStartOffset()
+                        : 0;
+                int endOffset = embeddingInfo.hasOriginalCharEndOffset()
+                        ? embeddingInfo.getOriginalCharEndOffset()
+                        : 0;
+
+                assertThat(startOffset)
+                        .as(chunkContext + ": embedding_info.original_char_start_offset must be >= 0")
+                        .isGreaterThanOrEqualTo(0);
+
+                assertThat(endOffset)
+                        .as(chunkContext + ": embedding_info.original_char_end_offset must be >= original_char_start_offset")
+                        .isGreaterThanOrEqualTo(startOffset);
+            }
+        }
+
+        // §5.2: nlp_analysis preserved from stage 1 — at least one SPR per unique
+        // source_field_name must still have nlp_analysis set.
+        Set<String> sourceFieldsInResults = results.stream()
+                .map(SemanticProcessingResult::getSourceFieldName)
+                .collect(Collectors.toSet());
+
+        for (String sourceField : sourceFieldsInResults) {
+            boolean hasNlpForSource = results.stream()
+                    .filter(spr -> sourceField.equals(spr.getSourceFieldName()))
+                    .anyMatch(SemanticProcessingResult::hasNlpAnalysis);
+            assertThat(hasNlpForSource)
+                    .as("post-embedder: at least one SPR with source_field_name='%s' "
+                            + "must have nlp_analysis set (preserved from stage 1 per DESIGN.md §5.2)", sourceField)
+                    .isTrue();
+        }
+
+        // §5.2: source_field_analytics[] preserved from stage 1 — entry per unique
+        // (source_field, chunk_config_id) pair.
+        Set<String> pairsInResults = results.stream()
+                .map(spr -> spr.getSourceFieldName() + "|" + spr.getChunkConfigId())
+                .collect(Collectors.toSet());
+
+        Set<String> pairsInAnalytics = sm.getSourceFieldAnalyticsList().stream()
+                .map(sfa -> sfa.getSourceField() + "|" + sfa.getChunkConfigId())
+                .collect(Collectors.toSet());
+
+        for (String pair : pairsInResults) {
+            assertThat(pairsInAnalytics)
+                    .as("post-embedder: source_field_analytics[] must contain an entry for "
+                            + "(source_field, chunk_config_id)='%s' (preserved from stage 1 per DESIGN.md §5.2)", pair)
+                    .contains(pair);
+        }
+
+        assertLexSorted(sm, "post-embedder");
+    }
+
+    /**
+     * Asserts that the given {@code doc} satisfies the post-semantic-graph stage
+     * invariant as defined in DESIGN.md §5.3.
+     *
+     * <p>Checks performed:
+     * <ol>
+     *   <li>All the post-embedder-style structural checks (§5.2) on every SPR:
+     *       non-empty {@code embedding_config_id}, non-empty chunks, populated
+     *       text_content and vector on every chunk, non-empty {@code chunk_id},
+     *       non-negative and ordered offsets, {@code directive_key} preserved in
+     *       metadata, and embedder-config-id matches a VectorDirective when
+     *       directives are still present.</li>
+     *   <li>For every centroid SPR ({@code chunk_config_id} ends in {@code _centroid}):
+     *     <ul>
+     *       <li>{@code centroid_metadata} is set.</li>
+     *       <li>{@code centroid_metadata.granularity} is not {@code UNSPECIFIED}.</li>
+     *       <li>{@code centroid_metadata.source_vector_count} is strictly positive.</li>
+     *       <li>Exactly one chunk (enforced by the centroid-specific assertion below).</li>
+     *     </ul>
+     *   </li>
+     *   <li>For every semantic-boundary SPR ({@code chunk_config_id == "semantic"}):
+     *     <ul>
+     *       <li>{@code granularity == GRANULARITY_LEVEL_SEMANTIC_CHUNK}.</li>
+     *       <li>{@code semantic_config_id} is non-empty.</li>
+     *       <li>Chunk count is in {@code [1, MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT]}.</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@code nlp_analysis} preserved: for every unique {@code source_field_name}
+     *       in the results, at least one SPR with that source_field_name has
+     *       {@code nlp_analysis} set.</li>
+     *   <li>{@code source_field_analytics[]} preserved: for every unique
+     *       {@code (source_field, chunk_config_id)} pair where chunk_config_id is
+     *       NOT a centroid suffix and NOT {@code "semantic"}, the analytics entry
+     *       must still exist. Stage-3-added centroid and boundary SPRs do not
+     *       contribute to this check because they introduce new chunk_config_id
+     *       values that were never produced by the chunker step.</li>
+     *   <li>{@code semantic_results[]} is lex-sorted.</li>
+     * </ol>
+     *
+     * <p>Note: DESIGN.md §5.3 also requires a deep-equal check that all Stage 2
+     * SPRs are preserved unchanged in the pre-append portion of
+     * {@code semantic_results[]}. That check needs the Stage 2 doc as input and
+     * cannot be performed with a single-arg method. Callers that need byte-identity
+     * must diff their own stage-2 input against the stage-3 output.
+     *
+     * <p>Naming note: DESIGN.md §5.3 uses the identifier
+     * {@code semantic_granularity == "SEMANTIC_CHUNK"}. That text predates the
+     * proto definition; the actual field on {@code SemanticProcessingResult} is
+     * {@code optional GranularityLevel granularity = 11}. This method therefore
+     * checks {@code spr.getGranularity() == GRANULARITY_LEVEL_SEMANTIC_CHUNK},
+     * which is the semantic equivalent. A future DESIGN.md amendment will inline
+     * this reconciliation.
+     *
+     * @param doc the PipeDoc to validate
+     * @throws AssertionError if any invariant is violated
+     */
+    public static void assertPostSemanticGraph(PipeDoc doc) {
+        assertThat(doc.hasSearchMetadata())
+                .as("post-graph: search_metadata must be set on the PipeDoc")
+                .isTrue();
+
+        SearchMetadata sm = doc.getSearchMetadata();
+        List<SemanticProcessingResult> results = sm.getSemanticResultsList();
+
+        Set<String> advertisedEmbedderConfigIds = Collections.emptySet();
+        if (sm.hasVectorSetDirectives()) {
+            advertisedEmbedderConfigIds = sm.getVectorSetDirectives().getDirectivesList().stream()
+                    .map(VectorDirective::getEmbedderConfigsList)
+                    .flatMap(List::stream)
+                    .map(NamedEmbedderConfig::getConfigId)
+                    .collect(Collectors.toSet());
+        }
+
+        for (int i = 0; i < results.size(); i++) {
+            SemanticProcessingResult spr = results.get(i);
+            String sprContext = "post-graph: semantic_results[" + i + "]"
+                    + " (source_field_name='" + spr.getSourceFieldName()
+                    + "', chunk_config_id='" + spr.getChunkConfigId()
+                    + "', embedding_config_id='" + spr.getEmbeddingConfigId()
+                    + "', result_id='" + spr.getResultId() + "')";
+
+            // Post-embedder-style structural checks on every SPR.
+            assertThat(spr.getEmbeddingConfigId())
+                    .as(sprContext + ": embedding_config_id must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getSourceFieldName())
+                    .as(sprContext + ": source_field_name must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getChunkConfigId())
+                    .as(sprContext + ": chunk_config_id must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getChunksList())
+                    .as(sprContext + ": chunks must be non-empty")
+                    .isNotEmpty();
+
+            assertThat(spr.getMetadataMap())
+                    .as(sprContext + ": metadata must contain 'directive_key' entry (inherited through all stages per DESIGN.md §21.2)")
+                    .containsKey("directive_key");
+
+            if (!advertisedEmbedderConfigIds.isEmpty()) {
+                assertThat(advertisedEmbedderConfigIds)
+                        .as(sprContext + ": embedding_config_id must match a NamedEmbedderConfig "
+                                + "advertised in vector_set_directives (per DESIGN.md §5.3)")
+                        .contains(spr.getEmbeddingConfigId());
+            }
+
+            List<SemanticChunk> chunks = spr.getChunksList();
+            for (int j = 0; j < chunks.size(); j++) {
+                SemanticChunk chunk = chunks.get(j);
+                String chunkContext = sprContext + " chunk[" + j + "] (chunk_id='" + chunk.getChunkId() + "')";
+
+                ChunkEmbedding embeddingInfo = chunk.getEmbeddingInfo();
+
+                assertThat(embeddingInfo.getTextContent())
+                        .as(chunkContext + ": embedding_info.text_content must be non-empty")
+                        .isNotEmpty();
+
+                assertThat(embeddingInfo.getVectorList())
+                        .as(chunkContext + ": embedding_info.vector must be populated at stage 3")
+                        .isNotEmpty();
+
+                assertThat(chunk.getChunkId())
+                        .as(chunkContext + ": chunk_id must be non-empty")
+                        .isNotEmpty();
+
+                int startOffset = embeddingInfo.hasOriginalCharStartOffset()
+                        ? embeddingInfo.getOriginalCharStartOffset()
+                        : 0;
+                int endOffset = embeddingInfo.hasOriginalCharEndOffset()
+                        ? embeddingInfo.getOriginalCharEndOffset()
+                        : 0;
+
+                assertThat(startOffset)
+                        .as(chunkContext + ": embedding_info.original_char_start_offset must be >= 0")
+                        .isGreaterThanOrEqualTo(0);
+
+                assertThat(endOffset)
+                        .as(chunkContext + ": embedding_info.original_char_end_offset must be >= original_char_start_offset")
+                        .isGreaterThanOrEqualTo(startOffset);
+            }
+
+            // Stage-3-specific checks keyed on chunk_config_id shape.
+            String cfg = spr.getChunkConfigId();
+            if (cfg.endsWith("_centroid")) {
+                assertThat(spr.hasCentroidMetadata())
+                        .as(sprContext + ": centroid SPR must have centroid_metadata set")
+                        .isTrue();
+
+                CentroidMetadata cm = spr.getCentroidMetadata();
+                assertThat(cm.getGranularity())
+                        .as(sprContext + ": centroid_metadata.granularity must not be GRANULARITY_LEVEL_UNSPECIFIED")
+                        .isNotEqualTo(GranularityLevel.GRANULARITY_LEVEL_UNSPECIFIED);
+
+                assertThat(cm.getSourceVectorCount())
+                        .as(sprContext + ": centroid_metadata.source_vector_count must be strictly positive")
+                        .isGreaterThan(0);
+
+                assertThat(spr.getChunksCount())
+                        .as(sprContext + ": centroid SPR must have exactly one chunk")
+                        .isEqualTo(1);
+            }
+
+            if ("semantic".equals(cfg)) {
+                assertThat(spr.hasGranularity())
+                        .as(sprContext + ": semantic-boundary SPR must have granularity set")
+                        .isTrue();
+
+                assertThat(spr.getGranularity())
+                        .as(sprContext + ": semantic-boundary SPR granularity must be GRANULARITY_LEVEL_SEMANTIC_CHUNK")
+                        .isEqualTo(GranularityLevel.GRANULARITY_LEVEL_SEMANTIC_CHUNK);
+
+                assertThat(spr.getSemanticConfigId())
+                        .as(sprContext + ": semantic-boundary SPR must have semantic_config_id set")
+                        .isNotEmpty();
+
+                assertThat(spr.getChunksCount())
+                        .as(sprContext + ": semantic-boundary SPR chunk count must be <= %d (default cap)",
+                                MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT)
+                        .isLessThanOrEqualTo(MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT);
+            }
+        }
+
+        // nlp_analysis preserved: at least one SPR per unique source_field_name
+        // must still have nlp_analysis set.
+        Set<String> sourceFieldsInResults = results.stream()
+                .map(SemanticProcessingResult::getSourceFieldName)
+                .collect(Collectors.toSet());
+
+        for (String sourceField : sourceFieldsInResults) {
+            boolean hasNlpForSource = results.stream()
+                    .filter(spr -> sourceField.equals(spr.getSourceFieldName()))
+                    .anyMatch(SemanticProcessingResult::hasNlpAnalysis);
+            assertThat(hasNlpForSource)
+                    .as("post-graph: at least one SPR with source_field_name='%s' "
+                            + "must have nlp_analysis set (preserved from stage 1 per DESIGN.md §5.3)", sourceField)
+                    .isTrue();
+        }
+
+        // source_field_analytics preserved: check only non-centroid, non-boundary SPRs.
+        // Stage-3-added SPRs (centroids, boundaries) introduce chunk_config_id values
+        // that the chunker step never produced, so they are not expected to have
+        // matching analytics entries.
+        Set<String> stage1Pairs = results.stream()
+                .filter(spr -> !spr.getChunkConfigId().endsWith("_centroid"))
+                .filter(spr -> !"semantic".equals(spr.getChunkConfigId()))
+                .map(spr -> spr.getSourceFieldName() + "|" + spr.getChunkConfigId())
+                .collect(Collectors.toSet());
+
+        Set<String> pairsInAnalytics = sm.getSourceFieldAnalyticsList().stream()
+                .map(sfa -> sfa.getSourceField() + "|" + sfa.getChunkConfigId())
+                .collect(Collectors.toSet());
+
+        for (String pair : stage1Pairs) {
+            assertThat(pairsInAnalytics)
+                    .as("post-graph: source_field_analytics[] must contain an entry for "
+                            + "(source_field, chunk_config_id)='%s' (preserved from stage 1 per DESIGN.md §5.3)", pair)
+                    .contains(pair);
+        }
+
+        assertLexSorted(sm, "post-graph");
+    }
+
+    /**
+     * Verifies that {@code semantic_results[]} is sorted in lexicographic ascending order
+     * on the tuple {@code (source_field_name, chunk_config_id, embedding_config_id, result_id)},
+     * as required by DESIGN.md §5.1, §5.2, and §21.8.
+     *
+     * @param sm the SearchMetadata whose semantic_results to validate
+     * @param stageLabel prefix for assertion messages (e.g. "post-chunker", "post-embedder")
+     * @throws AssertionError if the list is not sorted
+     */
+    private static void assertLexSorted(SearchMetadata sm, String stageLabel) {
+        List<SemanticProcessingResult> results = sm.getSemanticResultsList();
+
+        Comparator<SemanticProcessingResult> lexOrder = Comparator
+                .comparing(SemanticProcessingResult::getSourceFieldName)
+                .thenComparing(SemanticProcessingResult::getChunkConfigId)
+                .thenComparing(SemanticProcessingResult::getEmbeddingConfigId)
+                .thenComparing(SemanticProcessingResult::getResultId);
+
+        for (int i = 1; i < results.size(); i++) {
+            SemanticProcessingResult prev = results.get(i - 1);
+            SemanticProcessingResult curr = results.get(i);
+            int cmp = lexOrder.compare(prev, curr);
+            assertThat(cmp)
+                    .as(stageLabel + ": semantic_results must be lex-sorted by "
+                            + "(source_field_name, chunk_config_id, embedding_config_id, result_id). "
+                            + "Element at index " + (i - 1) + " (source_field='" + prev.getSourceFieldName()
+                            + "', chunk_config='" + prev.getChunkConfigId()
+                            + "', embedding_config='" + prev.getEmbeddingConfigId()
+                            + "', result_id='" + prev.getResultId() + "') "
+                            + "must come before or equal element at index " + i
+                            + " (source_field='" + curr.getSourceFieldName()
+                            + "', chunk_config='" + curr.getChunkConfigId()
+                            + "', embedding_config='" + curr.getEmbeddingConfigId()
+                            + "', result_id='" + curr.getResultId() + "')")
+                    .isLessThanOrEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/ai/pipestream/wiremock/client/semantic/SemanticPipelineInvariantsTest.java
+++ b/src/test/java/ai/pipestream/wiremock/client/semantic/SemanticPipelineInvariantsTest.java
@@ -1,0 +1,1001 @@
+package ai.pipestream.wiremock.client.semantic;
+
+import ai.pipestream.data.v1.CentroidMetadata;
+import ai.pipestream.data.v1.ChunkEmbedding;
+import ai.pipestream.data.v1.GranularityLevel;
+import ai.pipestream.data.v1.NamedEmbedderConfig;
+import ai.pipestream.data.v1.NlpDocumentAnalysis;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.data.v1.SearchMetadata;
+import ai.pipestream.data.v1.SemanticChunk;
+import ai.pipestream.data.v1.SemanticProcessingResult;
+import ai.pipestream.data.v1.SourceFieldAnalytics;
+import ai.pipestream.data.v1.VectorDirective;
+import ai.pipestream.data.v1.VectorSetDirectives;
+import com.google.protobuf.Value;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the happy path and failure paths for all three stage invariants in
+ * {@link SemanticPipelineInvariants}:
+ * {@link SemanticPipelineInvariants#assertPostChunker(PipeDoc)},
+ * {@link SemanticPipelineInvariants#assertPostEmbedder(PipeDoc)}, and
+ * {@link SemanticPipelineInvariants#assertPostSemanticGraph(PipeDoc)}.
+ */
+class SemanticPipelineInvariantsTest {
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Builds a minimal {@link ChunkEmbedding} that satisfies all post-chunker
+     * chunk-level invariants: non-empty text_content, empty vector, non-negative
+     * and ordered offsets.
+     */
+    private static ChunkEmbedding validChunkEmbedding(String text, int startOffset, int endOffset) {
+        return ChunkEmbedding.newBuilder()
+                .setTextContent(text)
+                // vector intentionally omitted (empty = not yet embedded)
+                .setOriginalCharStartOffset(startOffset)
+                .setOriginalCharEndOffset(endOffset)
+                .build();
+    }
+
+    /**
+     * Builds a minimal {@link SemanticChunk} that satisfies all post-chunker
+     * chunk-level invariants.
+     */
+    private static SemanticChunk validChunk(String chunkId, String text, int startOffset, int endOffset) {
+        return SemanticChunk.newBuilder()
+                .setChunkId(chunkId)
+                .setChunkNumber(0)
+                .setEmbeddingInfo(validChunkEmbedding(text, startOffset, endOffset))
+                .build();
+    }
+
+    /**
+     * Builds a {@link SemanticProcessingResult} that satisfies all post-chunker
+     * SPR-level invariants: empty embedding_config_id, non-empty source_field_name
+     * and chunk_config_id, at least one valid chunk, a directive_key in metadata,
+     * and nlp_analysis set (required per DESIGN.md §5.1).
+     */
+    private static SemanticProcessingResult validSpr(
+            String resultId,
+            String sourceFieldName,
+            String chunkConfigId,
+            String directiveKey) {
+        return SemanticProcessingResult.newBuilder()
+                .setResultId(resultId)
+                .setSourceFieldName(sourceFieldName)
+                .setChunkConfigId(chunkConfigId)
+                .setEmbeddingConfigId("") // placeholder — not yet embedded
+                .addChunks(validChunk("chunk-0", "Hello world, this is a test chunk.", 0, 34))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue(directiveKey).build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+    }
+
+    /**
+     * Builds a minimal {@link SourceFieldAnalytics} entry for the given
+     * (source_field, chunk_config_id) pair, satisfying the post-chunker
+     * requirement that source_field_analytics[] has one entry per unique pair
+     * present in semantic_results.
+     */
+    private static SourceFieldAnalytics validSourceFieldAnalytics(String sourceField, String chunkConfigId) {
+        return SourceFieldAnalytics.newBuilder()
+                .setSourceField(sourceField)
+                .setChunkConfigId(chunkConfigId)
+                .build();
+    }
+
+    /**
+     * Builds a {@link SemanticChunk} with a populated float vector of the given
+     * dimension. The vector values are deterministic (sin-based) so tests are
+     * reproducible and diffable.
+     */
+    private static SemanticChunk validStage2Chunk(String chunkId, String text, int startOffset, int endOffset, int dim) {
+        ChunkEmbedding.Builder embedding = ChunkEmbedding.newBuilder()
+                .setTextContent(text)
+                .setOriginalCharStartOffset(startOffset)
+                .setOriginalCharEndOffset(endOffset);
+        for (int i = 0; i < dim; i++) {
+            embedding.addVector((float) Math.sin((double) i + text.hashCode()));
+        }
+        return SemanticChunk.newBuilder()
+                .setChunkId(chunkId)
+                .setChunkNumber(0)
+                .setEmbeddingInfo(embedding.build())
+                .build();
+    }
+
+    /**
+     * Builds a stage-2 {@link SemanticProcessingResult}: non-empty embedding_config_id,
+     * populated vector on every chunk, nlp_analysis preserved, directive_key preserved.
+     */
+    private static SemanticProcessingResult validStage2Spr(
+            String resultId,
+            String sourceFieldName,
+            String chunkConfigId,
+            String embeddingConfigId,
+            String directiveKey,
+            int vectorDimension) {
+        return SemanticProcessingResult.newBuilder()
+                .setResultId(resultId)
+                .setSourceFieldName(sourceFieldName)
+                .setChunkConfigId(chunkConfigId)
+                .setEmbeddingConfigId(embeddingConfigId)
+                .addChunks(validStage2Chunk("chunk-0", "Hello world, this is a test chunk.", 0, 34, vectorDimension))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue(directiveKey).build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+    }
+
+    /**
+     * Builds a {@link VectorSetDirectives} advertising the given embedder config ids
+     * on a single directive keyed on the given source label. Used so stage-2 SPRs
+     * can pass the directive-lookup invariant in post-embedder checks.
+     */
+    private static VectorSetDirectives directivesAdvertising(String sourceLabel, String... embedderConfigIds) {
+        VectorDirective.Builder directive = VectorDirective.newBuilder()
+                .setSourceLabel(sourceLabel)
+                .setCelSelector("document." + sourceLabel);
+        for (String id : embedderConfigIds) {
+            directive.addEmbedderConfigs(NamedEmbedderConfig.newBuilder().setConfigId(id).build());
+        }
+        return VectorSetDirectives.newBuilder()
+                .addDirectives(directive.build())
+                .build();
+    }
+
+    /**
+     * Builds a minimal valid stage-3 centroid {@link SemanticProcessingResult}:
+     * chunk_config_id ends in "_centroid", centroid_metadata set with valid
+     * granularity and positive source_vector_count, exactly one chunk with a
+     * populated vector. Inherits the parent SPR's embedding_config_id and
+     * directive_key so the post-graph structural checks still pass.
+     */
+    private static SemanticProcessingResult validCentroidSpr(
+            String sourceFieldName,
+            String chunkConfigIdWithCentroidSuffix,
+            String embeddingConfigId,
+            String directiveKey,
+            GranularityLevel granularity,
+            int sourceVectorCount,
+            int vectorDimension) {
+        return SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:docHash123:" + sourceFieldName + ":" + chunkConfigIdWithCentroidSuffix + ":" + embeddingConfigId)
+                .setSourceFieldName(sourceFieldName)
+                .setChunkConfigId(chunkConfigIdWithCentroidSuffix)
+                .setEmbeddingConfigId(embeddingConfigId)
+                .addChunks(validStage2Chunk("centroid-0", "Representative centroid text", 0, 28, vectorDimension))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue(directiveKey).build())
+                .setCentroidMetadata(CentroidMetadata.newBuilder()
+                        .setGranularity(granularity)
+                        .setSourceVectorCount(sourceVectorCount)
+                        .build())
+                .build();
+    }
+
+    /**
+     * Builds a minimal valid stage-3 semantic-boundary {@link SemanticProcessingResult}:
+     * chunk_config_id="semantic", granularity=SEMANTIC_CHUNK, non-empty
+     * semantic_config_id, and the given number of chunks each with populated vectors.
+     */
+    private static SemanticProcessingResult validBoundarySpr(
+            String sourceFieldName,
+            String embeddingConfigId,
+            String directiveKey,
+            String semanticConfigId,
+            int chunkCount,
+            int vectorDimension) {
+        SemanticProcessingResult.Builder builder = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:docHash123:" + sourceFieldName + ":semantic:" + embeddingConfigId)
+                .setSourceFieldName(sourceFieldName)
+                .setChunkConfigId("semantic")
+                .setEmbeddingConfigId(embeddingConfigId)
+                .setGranularity(GranularityLevel.GRANULARITY_LEVEL_SEMANTIC_CHUNK)
+                .setSemanticConfigId(semanticConfigId)
+                .putMetadata("directive_key", Value.newBuilder().setStringValue(directiveKey).build());
+        for (int i = 0; i < chunkCount; i++) {
+            builder.addChunks(validStage2Chunk("semantic-" + i, "Boundary chunk " + i, 0, 20, vectorDimension));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Builds a minimal valid stage-3 {@link PipeDoc}: one preserved stage-2 SPR
+     * (for source_field=body, chunk_config=sentence_v1, embedder=minilm), one
+     * centroid SPR for the document, one semantic-boundary SPR, matching
+     * source_field_analytics for the stage-2 pair only, and directives that
+     * advertise the embedder config id. Passes
+     * {@link SemanticPipelineInvariants#assertPostSemanticGraph(PipeDoc)}.
+     *
+     * <p>The result list is lex-sorted by (source_field, chunk_config_id,
+     * embedding_config_id, result_id). At source_field="body":
+     * document_centroid &lt; semantic &lt; sentence_v1, so the centroid comes first,
+     * boundary second, stage-2 third.
+     */
+    private static PipeDoc validPostGraphDoc() {
+        SemanticProcessingResult centroid = validCentroidSpr(
+                "body",
+                "document_centroid",
+                "minilm",
+                "sha256b64url-abc123",
+                GranularityLevel.GRANULARITY_LEVEL_DOCUMENT,
+                4,
+                4);
+
+        SemanticProcessingResult boundary = validBoundarySpr(
+                "body",
+                "minilm",
+                "sha256b64url-abc123",
+                "semantic_v1",
+                3,
+                4);
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(centroid)
+                .addSemanticResults(boundary)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        return PipeDoc.newBuilder()
+                .setDocId("doc-stage3-001")
+                .setSearchMetadata(sm)
+                .build();
+    }
+
+    /**
+     * Builds a minimal valid stage-2 {@link PipeDoc} with a single SPR, a matching
+     * source_field_analytics entry, and a vector_set_directives block that advertises
+     * the SPR's embedding_config_id. Passes
+     * {@link SemanticPipelineInvariants#assertPostEmbedder(PipeDoc)}.
+     */
+    private static PipeDoc validPostEmbedderDoc() {
+        SemanticProcessingResult spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        return PipeDoc.newBuilder()
+                .setDocId("doc-stage2-001")
+                .setSearchMetadata(sm)
+                .build();
+    }
+
+    /**
+     * Builds a minimal valid {@link PipeDoc} with a single SPR and a matching
+     * source_field_analytics entry that passes
+     * {@link SemanticPipelineInvariants#assertPostChunker(PipeDoc)}.
+     */
+    private static PipeDoc validPostChunkerDoc() {
+        SemanticProcessingResult spr = validSpr(
+                "stage1:docHash123:body:sentence_v1:",
+                "body",
+                "sentence_v1",
+                "sha256b64url-abc123");
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .build();
+
+        return PipeDoc.newBuilder()
+                .setDocId("doc-001")
+                .setSearchMetadata(sm)
+                .build();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void validPostChunkerDocPasses() {
+        PipeDoc doc = validPostChunkerDoc();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc that satisfies all post-chunker invariants should not throw any exception")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void invalidPostChunkerDocFails_missingDirectiveKey() {
+        // Build an SPR that is missing the required directive_key in its metadata.
+        SemanticProcessingResult sprWithoutDirectiveKey = SemanticProcessingResult.newBuilder()
+                .setResultId("stage1:docHash123:body:sentence_v1:")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("") // still a placeholder
+                .addChunks(validChunk("chunk-0", "Some text content here.", 0, 23))
+                // deliberately omit directive_key from metadata
+                .putMetadata("some_other_key", Value.newBuilder().setStringValue("irrelevant").build())
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(sprWithoutDirectiveKey)
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-002")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc whose SPR metadata is missing 'directive_key' must fail the post-chunker assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("directive_key");
+    }
+
+    @Test
+    void invalidPostChunkerDocFails_nonEmptyVector() {
+        // Build an SPR whose chunk already has an embedding vector — that is invalid
+        // at the post-chunker stage; vectors must be empty placeholders.
+        ChunkEmbedding embeddingWithVector = ChunkEmbedding.newBuilder()
+                .setTextContent("Pre-embedded text — this is wrong at stage 1.")
+                .addVector(0.1f)
+                .addVector(0.2f)
+                .addVector(0.3f)
+                .setOriginalCharStartOffset(0)
+                .setOriginalCharEndOffset(46)
+                .build();
+
+        SemanticChunk chunkWithVector = SemanticChunk.newBuilder()
+                .setChunkId("chunk-premature-embed")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(embeddingWithVector)
+                .build();
+
+        SemanticProcessingResult sprWithVector = SemanticProcessingResult.newBuilder()
+                .setResultId("stage1:docHash123:body:sentence_v1:")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("")
+                .addChunks(chunkWithVector)
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(sprWithVector)
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-003")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc whose chunk has a non-empty vector at stage 1 must fail the post-chunker assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("vector must be empty");
+    }
+
+    @Test
+    void invalidPostChunkerDocFails_outOfOrderResults() {
+        // Build two SPRs that are NOT lex-sorted: second has a source_field_name that
+        // sorts before the first alphabetically.
+        SemanticProcessingResult sprBody = validSpr(
+                "stage1:docHash:body:sentence_v1:",
+                "body",
+                "sentence_v1",
+                "key-body");
+
+        SemanticProcessingResult sprAbstract = validSpr(
+                "stage1:docHash:abstract:sentence_v1:",
+                "abstract",
+                "sentence_v1",
+                "key-abstract");
+
+        // Deliberately put body before abstract — wrong lex order.
+        // Include source_field_analytics for both pairs so that check passes
+        // and the lex-sort check is the one that fires.
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(sprBody)
+                .addSemanticResults(sprAbstract)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("abstract", "sentence_v1"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-004")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThat(doc.getSearchMetadata().getSemanticResultsList())
+                .as("test fixture sanity: outOfOrderResults doc should contain exactly 2 SPRs (body before abstract)")
+                .hasSize(2);
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc whose semantic_results are not lex-sorted must fail the post-chunker assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("lex-sorted");
+    }
+
+    @Test
+    void invalidPostChunkerDocFails_missingSearchMetadata() {
+        // A bare PipeDoc with no search_metadata set at all must fail
+        // the very first guard in assertPostChunker.
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-007")
+                // deliberately NOT calling .setSearchMetadata(...)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc with no search_metadata set must fail the post-chunker assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("search_metadata must be set");
+    }
+
+    @Test
+    void invalidPostChunkerDocFails_missingNlpAnalysis() {
+        // Build an SPR WITHOUT nlp_analysis — explicit omission of setNlpAnalysis().
+        SemanticProcessingResult sprWithoutNlp = SemanticProcessingResult.newBuilder()
+                .setResultId("stage1:docHash123:body:sentence_v1:")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("")
+                .addChunks(validChunk("chunk-0", "Hello world, this is a test chunk.", 0, 34))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                // deliberately NOT calling .setNlpAnalysis(...)
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(sprWithoutNlp)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-005")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc where no SPR for source_field='body' has nlp_analysis must "
+                        + "fail the post-chunker assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("nlp_analysis");
+    }
+
+    @Test
+    void invalidPostChunkerDocFails_missingSourceFieldAnalytics() {
+        // Build a valid SPR but DO NOT add the corresponding source_field_analytics entry.
+        SemanticProcessingResult spr = validSpr(
+                "stage1:docHash123:body:sentence_v1:",
+                "body",
+                "sentence_v1",
+                "sha256b64url-abc123");
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                // deliberately NOT adding source_field_analytics for (body, sentence_v1)
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-006")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostChunker(doc))
+                .as("a PipeDoc missing a source_field_analytics entry for its (body, sentence_v1) "
+                        + "pair must fail the post-chunker assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("source_field_analytics");
+    }
+
+    // ---------------------------------------------------------------------------
+    // assertPostEmbedder tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void validPostEmbedderDocPasses() {
+        PipeDoc doc = validPostEmbedderDoc();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a PipeDoc that satisfies all post-embedder invariants should not throw any exception")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void invalidPostEmbedderDocFails_emptyEmbeddingConfigId() {
+        // Build an SPR that still looks like a stage-1 placeholder — embedding_config_id
+        // is empty. Post-embedder must reject this.
+        SemanticProcessingResult placeholderSpr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage1:docHash123:body:sentence_v1:")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("") // still a placeholder — wrong at stage 2
+                .addChunks(validStage2Chunk("chunk-0", "Already embedded text", 0, 21, 4))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(placeholderSpr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage2-002")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a PipeDoc whose SPR still has empty embedding_config_id must fail the post-embedder assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("embedding_config_id must be non-empty");
+    }
+
+    @Test
+    void invalidPostEmbedderDocFails_emptyVector() {
+        // Build an SPR whose chunk has non-empty embedding_config_id but an empty vector.
+        // Post-embedder must reject this because the embed step should have populated it.
+        ChunkEmbedding emptyVectorEmbedding = ChunkEmbedding.newBuilder()
+                .setTextContent("text without vector at stage 2")
+                // vector deliberately empty
+                .setOriginalCharStartOffset(0)
+                .setOriginalCharEndOffset(30)
+                .build();
+
+        SemanticChunk chunkWithoutVector = SemanticChunk.newBuilder()
+                .setChunkId("chunk-0")
+                .setChunkNumber(0)
+                .setEmbeddingInfo(emptyVectorEmbedding)
+                .build();
+
+        SemanticProcessingResult spr = SemanticProcessingResult.newBuilder()
+                .setResultId("stage2:docHash123:body:sentence_v1:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("sentence_v1")
+                .setEmbeddingConfigId("minilm")
+                .addChunks(chunkWithoutVector)
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                .setNlpAnalysis(NlpDocumentAnalysis.getDefaultInstance())
+                .build();
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage2-003")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a PipeDoc whose stage-2 SPR chunk has an empty vector must fail the post-embedder assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("vector must be populated");
+    }
+
+    @Test
+    void invalidPostEmbedderDocFails_embeddingConfigIdNotAdvertised() {
+        // Build an SPR with embedding_config_id="phantom" but the directives only
+        // advertise "minilm". Post-embedder must reject because the SPR references
+        // an embedder config that no VectorDirective advertises.
+        SemanticProcessingResult spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:phantom",
+                "body",
+                "sentence_v1",
+                "phantom",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm")) // does NOT include "phantom"
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage2-004")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a PipeDoc whose SPR embedding_config_id is not advertised in any VectorDirective "
+                        + "must fail the post-embedder assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("must match a NamedEmbedderConfig");
+    }
+
+    @Test
+    void validPostEmbedderDocWithoutDirectivesPasses() {
+        // If vector_set_directives is cleared after stage 1 processing, the
+        // advertised-config-id cross-check must be silently skipped rather than
+        // failing. This test exercises that guard.
+        PipeDoc doc = validPostEmbedderDoc().toBuilder()
+                .setSearchMetadata(validPostEmbedderDoc().getSearchMetadata().toBuilder()
+                        .clearVectorSetDirectives()
+                        .build())
+                .build();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a valid post-embedder doc without vector_set_directives should still pass "
+                        + "(the advertised-config-id cross-check is skipped when directives are absent)")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void invalidPostEmbedderDocFails_outOfOrderResults() {
+        // Two valid stage-2 SPRs deliberately inserted in wrong lex order
+        // (body before abstract). Source analytics entries + directives present
+        // for both so the lex-sort check is the one that fires.
+        SemanticProcessingResult sprBody = validStage2Spr(
+                "stage2:docHash:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-body",
+                4);
+        SemanticProcessingResult sprAbstract = validStage2Spr(
+                "stage2:docHash:abstract:sentence_v1:minilm",
+                "abstract",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abstract",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(sprBody)
+                .addSemanticResults(sprAbstract)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("abstract", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage2-006")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a post-embedder doc whose semantic_results are not lex-sorted must fail")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("lex-sorted");
+    }
+
+    @Test
+    void invalidPostEmbedderDocFails_missingSearchMetadata() {
+        // Bare PipeDoc with no search_metadata must fail the first guard.
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage2-005")
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostEmbedder(doc))
+                .as("a PipeDoc with no search_metadata set must fail the post-embedder assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("search_metadata must be set");
+    }
+
+    // ---------------------------------------------------------------------------
+    // assertPostSemanticGraph tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void validPostGraphDocPasses() {
+        PipeDoc doc = validPostGraphDoc();
+
+        assertThatCode(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a PipeDoc that satisfies all post-semantic-graph invariants should not throw any exception")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void invalidPostGraphDocFails_centroidMissingCentroidMetadata() {
+        // Build a centroid SPR (chunk_config_id="document_centroid") but do NOT
+        // set centroid_metadata. Must fail the post-graph centroid-specific check.
+        SemanticProcessingResult badCentroid = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:docHash123:body:document_centroid:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("document_centroid")
+                .setEmbeddingConfigId("minilm")
+                .addChunks(validStage2Chunk("centroid-0", "Centroid without metadata", 0, 25, 4))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                // deliberately NOT calling setCentroidMetadata
+                .build();
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(badCentroid)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-002")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a centroid SPR without centroid_metadata must fail the post-graph assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("centroid_metadata");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_centroidZeroSourceVectorCount() {
+        // Centroid SPR with centroid_metadata set but source_vector_count=0.
+        SemanticProcessingResult badCentroid = validCentroidSpr(
+                "body",
+                "document_centroid",
+                "minilm",
+                "sha256b64url-abc123",
+                GranularityLevel.GRANULARITY_LEVEL_DOCUMENT,
+                0, // must be strictly positive
+                4);
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(badCentroid)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-003")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a centroid SPR with source_vector_count=0 must fail the post-graph assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("source_vector_count");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_boundaryMissingSemanticConfigId() {
+        // Boundary SPR (chunk_config_id="semantic") with no semantic_config_id.
+        SemanticProcessingResult badBoundary = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:docHash123:body:semantic:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("semantic")
+                .setEmbeddingConfigId("minilm")
+                .setGranularity(GranularityLevel.GRANULARITY_LEVEL_SEMANTIC_CHUNK)
+                // deliberately NOT setting semantic_config_id
+                .addChunks(validStage2Chunk("semantic-0", "Boundary chunk", 0, 14, 4))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                .build();
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(badBoundary)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-004")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a semantic-boundary SPR with empty semantic_config_id must fail the post-graph assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("semantic_config_id");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_boundaryWrongGranularity() {
+        // Boundary SPR (chunk_config_id="semantic") with granularity=PARAGRAPH
+        // instead of the required SEMANTIC_CHUNK.
+        SemanticProcessingResult badBoundary = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:docHash123:body:semantic:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("semantic")
+                .setEmbeddingConfigId("minilm")
+                .setGranularity(GranularityLevel.GRANULARITY_LEVEL_PARAGRAPH) // wrong
+                .setSemanticConfigId("semantic_v1")
+                .addChunks(validStage2Chunk("semantic-0", "Boundary chunk", 0, 14, 4))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                .build();
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(badBoundary)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-005")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a semantic-boundary SPR with granularity != SEMANTIC_CHUNK must fail the post-graph assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("GRANULARITY_LEVEL_SEMANTIC_CHUNK");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_boundaryExceedsMaxChunkCap() {
+        // Boundary SPR with chunkCount > MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT (50).
+        int overCap = SemanticPipelineInvariants.MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT + 1;
+        SemanticProcessingResult badBoundary = validBoundarySpr(
+                "body",
+                "minilm",
+                "sha256b64url-abc123",
+                "semantic_v1",
+                overCap,
+                4);
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(badBoundary)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-006")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a semantic-boundary SPR whose chunk count exceeds the default cap (%d) must fail the post-graph assertion",
+                        SemanticPipelineInvariants.MAX_SEMANTIC_CHUNKS_PER_DOC_DEFAULT)
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("chunk count must be <=");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_centroidMultipleChunks() {
+        // Centroid SPR with TWO chunks — must fail the "exactly one chunk" rule.
+        SemanticProcessingResult multiChunkCentroid = SemanticProcessingResult.newBuilder()
+                .setResultId("stage3:docHash123:body:document_centroid:minilm")
+                .setSourceFieldName("body")
+                .setChunkConfigId("document_centroid")
+                .setEmbeddingConfigId("minilm")
+                .addChunks(validStage2Chunk("centroid-0", "First centroid chunk", 0, 20, 4))
+                .addChunks(validStage2Chunk("centroid-1", "Second centroid chunk", 0, 21, 4))
+                .putMetadata("directive_key", Value.newBuilder().setStringValue("sha256b64url-abc123").build())
+                .setCentroidMetadata(CentroidMetadata.newBuilder()
+                        .setGranularity(GranularityLevel.GRANULARITY_LEVEL_DOCUMENT)
+                        .setSourceVectorCount(4)
+                        .build())
+                .build();
+
+        SemanticProcessingResult stage2Spr = validStage2Spr(
+                "stage2:docHash123:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abc123",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(multiChunkCentroid)
+                .addSemanticResults(stage2Spr)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-008")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a centroid SPR with more than one chunk must fail the post-graph assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("exactly one chunk");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_outOfOrderResults() {
+        // Build two valid stage-2 SPRs in wrong lex order. No centroid/boundary
+        // at source_field="abstract" so the analytics-pair check on preserved
+        // SPRs covers both, and the lex-sort check is what fires.
+        SemanticProcessingResult sprBody = validStage2Spr(
+                "stage2:docHash:body:sentence_v1:minilm",
+                "body",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-body",
+                4);
+        SemanticProcessingResult sprAbstract = validStage2Spr(
+                "stage2:docHash:abstract:sentence_v1:minilm",
+                "abstract",
+                "sentence_v1",
+                "minilm",
+                "sha256b64url-abstract",
+                4);
+
+        SearchMetadata sm = SearchMetadata.newBuilder()
+                .addSemanticResults(sprBody)
+                .addSemanticResults(sprAbstract)
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("body", "sentence_v1"))
+                .addSourceFieldAnalytics(validSourceFieldAnalytics("abstract", "sentence_v1"))
+                .setVectorSetDirectives(directivesAdvertising("body", "minilm"))
+                .build();
+
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-009")
+                .setSearchMetadata(sm)
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a post-graph doc whose semantic_results are not lex-sorted must fail")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("lex-sorted");
+    }
+
+    @Test
+    void invalidPostGraphDocFails_missingSearchMetadata() {
+        PipeDoc doc = PipeDoc.newBuilder()
+                .setDocId("doc-stage3-007")
+                .build();
+
+        assertThatThrownBy(() -> SemanticPipelineInvariants.assertPostSemanticGraph(doc))
+                .as("a PipeDoc with no search_metadata set must fail the post-graph assertion")
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("search_metadata must be set");
+    }
+}


### PR DESCRIPTION
## Summary

Removes the test-time dependency on \`ai.pipestream:pipestream-test-support\` by inlining the 633-line \`SemanticPipelineInvariants\` helper (and its 1001-line unit test) into \`pipestream-wiremock-server\`'s own test sources at \`src/test/java/ai/pipestream/wiremock/client/semantic/\`.

## Why

PR [pipestream-platform#51](https://github.com/ai-pipestream/pipestream-platform/pull/51) added \`SemanticPipelineInvariants\` to \`pipestream-test-support/runtime\` alongside a \`proto-toolchain\` plugin configuration so the helper could reference \`PipeDoc\` / \`SemanticChunk\` / \`SemanticProcessingResult\` directly. That works fine for \`pipestream-wiremock-server\` (plain Java app) but it bundled proto-generated classes into a **Quarkus extension jar**, which created a classloader hazard for the three semantic-pipeline module consumers (module-chunker, -embedder, -semantic-graph). Each of those modules is a Quarkus application that generates its own copy of the same protos, and the extension-aware classloader bucketed them separately, producing \`NoClassDefFoundError\` on \`PipeDoc\` at runtime.

R1 (module-chunker) worked around it by inlining its own per-module copy of the post-chunker invariants. This PR lands the first half of reverting PR #51's shared-helper experiment: wiremock-server gets its own local copy of the helper + tests (one consumer, one copy — microservice pattern, not monolith), so a **follow-up PR on pipestream-platform** can delete \`SemanticPipelineInvariants.java\` from \`pipestream-test-support/runtime\` and strip the \`proto-toolchain\` plugin from its \`build.gradle\`, ending the hazard. That follow-up depends on this PR landing first.

## Changes

- Copy \`SemanticPipelineInvariants\` (633 LOC) and \`SemanticPipelineInvariantsTest\` (1001 LOC) into \`src/test/java/ai/pipestream/wiremock/client/semantic/\` with package rename only — zero logic changes
- Update \`SemanticPipelineInvariants\` class Javadoc to reflect the new inline-per-consumer ownership model (explicitly notes that module-chunker / -embedder / -semantic-graph each inline their own copy, no shared library)
- Update 4 step-mock test files (\`ChunkerStepMockTest\`, \`EmbedderStepMockTest\`, \`SemanticGraphStepMockTest\`, \`SemanticPipelineShowcaseTest\`) to import from the new package
- Drop \`testImplementation('ai.pipestream:pipestream-test-support:0.7.24-SNAPSHOT')\` from \`build.gradle\` — no longer needed
- Update \`SemanticFixtureBuilder\` main-scope Javadoc to point at the new location

## Test plan

- [x] \`./gradlew clean build\` — passes: 266 tests, 0 failures, 0 errors
- [x] \`ChunkerStepMockTest\`, \`EmbedderStepMockTest\`, \`SemanticGraphStepMockTest\`, \`SemanticPipelineShowcaseTest\` all green
- [x] \`SemanticPipelineInvariantsTest\` — all 23 cases green (positive + negative paths for all three stage invariants)
- [ ] CI green on PR

## Follow-up

Once this lands, open a matching PR on pipestream-platform that:
1. Deletes \`pipestream-test-support/runtime/src/main/java/ai/pipestream/test/support/semantic/SemanticPipelineInvariants.java\`
2. Deletes the sibling \`SemanticPipelineInvariantsTest.java\`
3. Strips the \`proto-toolchain\` plugin block from \`pipestream-test-support/runtime/build.gradle\`
4. Strips \`libs.pipestream.test.documents\`, \`libs.protobuf.java\`, and \`libs.assertj.core\` from main-scope deps (they were added for the helper)
5. Bumps BOM snapshot