### PR TITLE
feat(server): honor x-test-delay-ms header universally on all stubs

### DIFF
--- a/src/main/java/ai/pipestream/wiremock/server/DelayInjectionRequestFilter.java
+++ b/src/main/java/ai/pipestream/wiremock/server/DelayInjectionRequestFilter.java
@@ -1,0 +1,85 @@
+package ai.pipestream.wiremock.server;
+
+import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilterAction;
+import com.github.tomakehurst.wiremock.extension.requestfilter.StubRequestFilterV2;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.jboss.logging.Logger;
+
+/**
+ * WireMock stub request filter that honors the {@code x-test-delay-ms} request header
+ * by sleeping the matching server thread for that many milliseconds <em>before</em>
+ * stub matching/response generation runs.
+ *
+ * <p>This applies uniformly to every stub registered against the main WireMock server,
+ * including HTTP stubs and gRPC stubs served via {@code wiremock-grpc-extension}. It is
+ * the canonical mechanism for tests that need to simulate hung or slow downstream
+ * dependencies (gRPC and HTTP alike) without writing per-mock {@code fixedDelayMilliseconds}
+ * in stub definitions.</p>
+ *
+ * <p>Behaviour:</p>
+ * <ul>
+ *   <li>Header missing or non-numeric: filter is a no-op.</li>
+ *   <li>Header {@code <= 0}: no-op.</li>
+ *   <li>Header {@code > 0}: current thread sleeps for that many milliseconds, then the
+ *       request continues unchanged. If interrupted, the interrupt flag is restored and
+ *       processing continues so the client sees a normal (fast) response rather than a
+ *       hang.</li>
+ * </ul>
+ *
+ * <p>Admin endpoints are unaffected so {@code /__admin/*} stays responsive even when a
+ * test has set a global delay header on its client interceptor.</p>
+ */
+public class DelayInjectionRequestFilter implements StubRequestFilterV2 {
+
+    private static final Logger LOG = Logger.getLogger(DelayInjectionRequestFilter.class);
+
+    /** Header name clients send to request a delay. Lowercased per HTTP/2 / gRPC custom-metadata convention. */
+    public static final String DELAY_HEADER = "x-test-delay-ms";
+
+    @Override
+    public RequestFilterAction filter(Request request, ServeEvent serveEvent) {
+        HttpHeader header = request.header(DELAY_HEADER);
+        if (header == null || !header.isPresent()) {
+            return RequestFilterAction.continueWith(request);
+        }
+        String raw = header.firstValue();
+        long delayMs;
+        try {
+            delayMs = Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            LOG.debugf("Ignoring non-numeric %s header value: %s", DELAY_HEADER, raw);
+            return RequestFilterAction.continueWith(request);
+        }
+        if (delayMs <= 0) {
+            return RequestFilterAction.continueWith(request);
+        }
+
+        LOG.debugf("Honoring %s=%dms for %s request",
+                DELAY_HEADER, delayMs, request.getMethod());
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debugf("Interrupted while sleeping for %s=%dms; continuing without further delay",
+                    DELAY_HEADER, delayMs);
+        }
+        return RequestFilterAction.continueWith(request);
+    }
+
+    @Override
+    public boolean applyToAdmin() {
+        return false;
+    }
+
+    @Override
+    public boolean applyToStubs() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "delay-injection-request-filter";
+    }
+}

--- a/src/main/java/ai/pipestream/wiremock/server/DirectWireMockGrpcServer.java
+++ b/src/main/java/ai/pipestream/wiremock/server/DirectWireMockGrpcServer.java
@@ -74,7 +74,19 @@ public class DirectWireMockGrpcServer {
             String delayStr = headers.get(DELAY_MS_HEADER);
             if (delayStr != null) {
                 try {
-                    ctx = ctx.withValue(TEST_DELAY_MS_KEY, Integer.parseInt(delayStr));
+                    int delayMs = Integer.parseInt(delayStr);
+                    ctx = ctx.withValue(TEST_DELAY_MS_KEY, delayMs);
+                    // Honor the delay universally for every Direct gRPC service before
+                    // the call is dispatched. Individual service implementations no
+                    // longer need to repeat this Thread.sleep.
+                    if (delayMs > 0) {
+                        try {
+                            LOG.debugf("Honoring x-test-delay-ms=%dms on Direct gRPC server", delayMs);
+                            Thread.sleep(delayMs);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
                 } catch (NumberFormatException ignored) {
                     // Ignore invalid delay values
                 }
@@ -135,15 +147,7 @@ public class DirectWireMockGrpcServer {
             int size = request.getSerializedSize();
             String scenario = TEST_SCENARIO_KEY.get();
             String customDocId = TEST_DOC_ID_KEY.get();
-            Integer delayMs = TEST_DELAY_MS_KEY.get();
-
-            if (delayMs != null && delayMs > 0) {
-                try {
-                    Thread.sleep(delayMs);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+            // Note: x-test-delay-ms is honored centrally by TestMetadataInterceptor.
 
             if ("failure".equals(scenario)) {
                 responseObserver.onNext(UploadFilesystemPipeDocResponse.newBuilder()

--- a/src/main/java/ai/pipestream/wiremock/server/WiremockManager.java
+++ b/src/main/java/ai/pipestream/wiremock/server/WiremockManager.java
@@ -63,6 +63,7 @@ public class WiremockManager {
         }
         
         config.extensions(new GrpcExtensionFactory());
+        config.extensions(new DelayInjectionRequestFilter());
 
         wireMockServer = new WireMockServer(config);
         wireMockServer.start();

--- a/src/test/java/ai/pipestream/wiremock/server/DelayInjectionRequestFilterTest.java
+++ b/src/test/java/ai/pipestream/wiremock/server/DelayInjectionRequestFilterTest.java
@@ -1,0 +1,204 @@
+package ai.pipestream.wiremock.server;
+
+import ai.pipestream.data.v1.DocumentReference;
+import ai.pipestream.data.v1.PipeDoc;
+import ai.pipestream.repository.pipedoc.v1.GetPipeDocByReferenceRequest;
+import ai.pipestream.repository.pipedoc.v1.GetPipeDocByReferenceResponse;
+import ai.pipestream.repository.pipedoc.v1.PipeDocServiceGrpc;
+import ai.pipestream.wiremock.client.PipeDocServiceMock;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ForwardingClientCall;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.wiremock.grpc.GrpcExtensionFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link DelayInjectionRequestFilter} delays both HTTP and gRPC stubs when
+ * the {@code x-test-delay-ms} header is set, and is a no-op when the header is absent.
+ */
+class DelayInjectionRequestFilterTest {
+
+    private static final long DELAY_MS = 600L;
+    private static final long SLACK_MS = 250L;
+
+    private static WireMockServer wireMockServer;
+    private static WireMock wireMock;
+    private static ManagedChannel channel;
+
+    @BeforeAll
+    static void setUp() {
+        WireMockConfiguration cfg = WireMockConfiguration.options()
+                .dynamicPort()
+                .withRootDirectory("build/resources/test/wiremock");
+        cfg.extensions(new GrpcExtensionFactory());
+        cfg.extensions(new DelayInjectionRequestFilter());
+        wireMockServer = new WireMockServer(cfg);
+        wireMockServer.start();
+
+        wireMock = new WireMock(wireMockServer.port());
+
+        wireMock.register(get(urlEqualTo("/ping")).willReturn(aResponse().withBody("pong")));
+
+        channel = ManagedChannelBuilder.forAddress("localhost", wireMockServer.port())
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() throws InterruptedException {
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("HTTP stub: x-test-delay-ms causes server-side delay before responding")
+    void httpDelayHeaderDelaysResponse() throws IOException {
+        long t0 = System.nanoTime();
+        readWithDelayHeader("/ping", DELAY_MS);
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+        assertTrue(elapsedMs >= DELAY_MS - SLACK_MS,
+                "Expected at least " + (DELAY_MS - SLACK_MS) + "ms but got " + elapsedMs + "ms");
+        assertTrue(elapsedMs < DELAY_MS + 5_000L,
+                "Did not expect to wait significantly longer than " + DELAY_MS + "ms but got " + elapsedMs + "ms");
+    }
+
+    @Test
+    @DisplayName("HTTP stub: missing x-test-delay-ms means no delay")
+    void noHeaderMeansNoDelay() throws IOException {
+        long t0 = System.nanoTime();
+        readWithDelayHeader("/ping", -1);
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+        assertTrue(elapsedMs < DELAY_MS / 2,
+                "Expected fast response without header but took " + elapsedMs + "ms");
+    }
+
+    @Test
+    @DisplayName("gRPC stub (PipeDocService): x-test-delay-ms delays the gRPC response")
+    void grpcDelayHeaderDelaysGrpcResponse() {
+        PipeDocServiceMock mock = new PipeDocServiceMock(wireMock);
+        PipeDoc doc = PipeDoc.newBuilder().setDocId("delay-doc").build();
+        mock.registerPipeDoc("delay-doc", "acct", doc, "n1", "d1");
+
+        PipeDocServiceGrpc.PipeDocServiceBlockingStub delayingStub =
+                PipeDocServiceGrpc.newBlockingStub(channel)
+                        .withInterceptors(headerInterceptor("x-test-delay-ms", String.valueOf(DELAY_MS)));
+
+        DocumentReference ref = DocumentReference.newBuilder()
+                .setDocId("delay-doc")
+                .setAccountId("acct")
+                .build();
+
+        long t0 = System.nanoTime();
+        GetPipeDocByReferenceResponse response = delayingStub.getPipeDocByReference(
+                GetPipeDocByReferenceRequest.newBuilder().setDocumentRef(ref).build());
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+        assertNotNull(response);
+        assertTrue(response.hasPipedoc());
+        assertEquals("delay-doc", response.getPipedoc().getDocId());
+        assertTrue(elapsedMs >= DELAY_MS - SLACK_MS,
+                "Expected at least " + (DELAY_MS - SLACK_MS) + "ms but got " + elapsedMs + "ms");
+    }
+
+    @Test
+    @DisplayName("gRPC stub: client deadline shorter than configured delay surfaces DEADLINE_EXCEEDED")
+    void grpcDeadlineShorterThanDelayFailsFast() {
+        PipeDocServiceMock mock = new PipeDocServiceMock(wireMock);
+        PipeDoc doc = PipeDoc.newBuilder().setDocId("deadline-doc").build();
+        mock.registerPipeDoc("deadline-doc", "acct", doc, "n1", "d1");
+
+        long longDelay = 5_000L;
+        PipeDocServiceGrpc.PipeDocServiceBlockingStub stub =
+                PipeDocServiceGrpc.newBlockingStub(channel)
+                        .withInterceptors(headerInterceptor("x-test-delay-ms", String.valueOf(longDelay)))
+                        .withDeadlineAfter(750, TimeUnit.MILLISECONDS);
+
+        DocumentReference ref = DocumentReference.newBuilder()
+                .setDocId("deadline-doc")
+                .setAccountId("acct")
+                .build();
+
+        io.grpc.StatusRuntimeException ex = assertThrows(io.grpc.StatusRuntimeException.class,
+                () -> stub.getPipeDocByReference(
+                        GetPipeDocByReferenceRequest.newBuilder().setDocumentRef(ref).build()));
+
+        assertEquals(io.grpc.Status.Code.DEADLINE_EXCEEDED, ex.getStatus().getCode(),
+                "Expected DEADLINE_EXCEEDED but got: " + ex.getStatus());
+    }
+
+    private static void readWithDelayHeader(String path, long delayMs) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) URI.create(
+                "http://localhost:" + wireMockServer.port() + path).toURL().openConnection();
+        try {
+            if (delayMs >= 0) {
+                conn.setRequestProperty("x-test-delay-ms", String.valueOf(delayMs));
+            }
+            conn.setConnectTimeout(5_000);
+            conn.setReadTimeout(15_000);
+            int rc = conn.getResponseCode();
+            if (rc != 200) {
+                throw new IOException("Unexpected status: " + rc);
+            }
+            try (java.io.InputStream in = conn.getInputStream()) {
+                String body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                if (!"pong".equals(body)) {
+                    throw new IOException("Unexpected body: " + body);
+                }
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private static ClientInterceptor headerInterceptor(String name, String value) {
+        Metadata.Key<String> key = Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER);
+        return new ClientInterceptor() {
+            @Override
+            public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                    MethodDescriptor<ReqT, RespT> method,
+                    CallOptions callOptions,
+                    Channel next) {
+                return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+                    @Override
+                    public void start(Listener<RespT> responseListener, Metadata headers) {
+                        headers.put(key, value);
+                        super.start(responseListener, headers);
+                    }
+                };
+            }
+        };
+    }
+}


### PR DESCRIPTION
Adds a WireMock StubRequestFilterV2 that reads the `x-test-delay-ms` request header and sleeps for that many milliseconds before stub matching/response generation runs. This applies uniformly to every stub registered against the main WireMock server, including HTTP stubs and gRPC stubs served via wiremock-grpc-extension.

Tests can now simulate a hung downstream dependency (e.g. a wedged PipeDocService.GetPipeDocByReference) without authoring per-mock fixedDelayMilliseconds JSON, by simply attaching the header on the gRPC channel via a ClientInterceptor. Combined with a client-side gRPC deadline, this is the canonical mechanism for verifying timeout
+ retry + DLQ behaviour in callers (e.g. pipestream-engine-kafka-sidecar).

Also consolidates the existing per-service Thread.sleep on DirectWireMockGrpcServer into TestMetadataInterceptor so the same header is honored uniformly by all Direct gRPC services (NodeUploadServiceImpl no longer needs to repeat it).

Admin endpoints (/__admin/*) are unaffected so admin remains responsive even when a test sets a global delay header on its client.

Adds DelayInjectionRequestFilterTest verifying:
- HTTP request with header is delayed by the requested amount
- HTTP request without header is fast (no-op)
- gRPC PipeDocService.GetPipeDocByReference is delayed
- gRPC client deadline shorter than configured delay surfaces DEADLINE_EXCEEDED (the exact pattern callers will rely on)

Full suite: 270 tests, 0 failures.