### PR TITLE
build: upgrade Quarkus to 3.34.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.shadow)
     alias(libs.plugins.proto.toolchain)
     id 'idea'
-    id 'io.quarkus' version '3.34.5'
+    id 'io.quarkus' version '3.34.6'
 }
 
 scmVersion {
@@ -73,7 +73,7 @@ pipestreamProtos {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:3.34.5")
+    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:3.34.6")
     implementation 'io.quarkus:quarkus-arc'
 
     implementation libs.wiremock.core

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=0.1.52
-quarkusVersion=3.34.3
+quarkusVersion=3.34.6
 grpcVersion=1.79.0
 protobufVersion=4.33.5
 


### PR DESCRIPTION
Paired with pipestream-platform PR #73. Per `UPGRADING_QUARKUS_PROCESS.md`, wiremock-server doesn't consume the BOM so its Quarkus pin must be bumped independently. Three files touched (`gradle.properties` + two pins in `build.gradle`). Clean build green locally.